### PR TITLE
Message type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,6 @@ jobs:
           otp-version: 22.2
       - uses: gleam-lang/setup-gleam@v1.0.1
         with:
-          gleam-version: 0.8.0-rc1
+          gleam-version: 0.9.0
       - run: rebar3 install_deps
       - run: rebar3 eunit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,6 @@ jobs:
           otp-version: 22.2
       - uses: gleam-lang/setup-gleam@v1.0.1
         with:
-          gleam-version: 0.10.0-rc2
+          gleam-version: 0.10.0
       - run: rebar3 install_deps
       - run: rebar3 eunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - Add `Message`, `RequestHead` and `ResponseHead` types.
 - `http` module gains `request`, `request_uri`, `response`,
   `method`, `host`, `port`, `path`, `path_segments`,
-  `get_query`, `status`, `get_header`, `set_header`, `get_body`,
-  `set_body` and `redirect`.
+  `get_query`, `status`, `get_header`, `get_headers`, `set_header`,
+  `get_body`, `set_body` and `redirect`.
 
 ## v1.0.0 - 2020-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.1.0 - 2020-07-xx
+
+- Add `Message`, `RequestHead` and `ResponseHead` types.
+- `http` module gains `request`, `request_uri`, `response`,
+  `method`, `host`, `port`, `path`, `path_segments`,
+  `get_query`, `status`, `get_header`, `set_header`, `get_body`,
+  `set_body` and `redirect`.
+
 ## v1.0.0 - 2020-06-30
 
 - Initial release

--- a/rebar.config
+++ b/rebar.config
@@ -14,5 +14,5 @@
 {project_plugins, [rebar_gleam, rebar3_hex]}.
 
 {deps, [
-    {gleam_stdlib, {git, "https://github.com/gleam-lang/stdlib", {ref, "0925fba65fe2b3eeb03e88933130d7adf39d8b83"}}}
+    {gleam_stdlib, {git, "https://github.com/gleam-lang/stdlib", {ref, "a4ea7efadd177219711484255c671bd74248ace3"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -2,16 +2,17 @@
 {src_dirs, ["src", "gen/src"]}.
 
 {profiles, [
-    {test, [
-        {pre_hooks, [{compile, "gleam build ."}]},
-        {src_dirs, ["src", "test", "gen/src", "gen/test"]}
-    ]},
-
-    {dev, [
-        {pre_hooks, [{compile, "gleam build ."}]}
-    ]}
+    {test, [{src_dirs, ["src", "test", "gen/src", "gen/test"]}]}
 ]}.
 
+{shell, [
+    % {config, "config/sys.config"},
+    {apps, [gleam_stdlib]}
+]}.
+
+
+{project_plugins, [rebar_gleam, rebar3_hex]}.
+
 {deps, [
-    {gleam_stdlib, "0.8.0"}
+    {gleam_stdlib, {git, "https://github.com/gleam-lang/stdlib", {ref, "0925fba65fe2b3eeb03e88933130d7adf39d8b83"}}}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,4 @@
+[{<<"gleam_stdlib">>,
+  {git,"https://github.com/gleam-lang/stdlib",
+       {ref,"0925fba65fe2b3eeb03e88933130d7adf39d8b83"}},
+  0}].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,4 @@
 [{<<"gleam_stdlib">>,
   {git,"https://github.com/gleam-lang/stdlib",
-       {ref,"0925fba65fe2b3eeb03e88933130d7adf39d8b83"}},
+       {ref,"a4ea7efadd177219711484255c671bd74248ace3"}},
   0}].

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -96,7 +96,13 @@ pub type Response(body) =
   Message(ResponseHead, body)
 
 /// Construct a `Request` type.
-pub fn request(method: Method, host: String, port: Option(Int), path: String, query: Option(String)) -> Request(Nil) {
+pub fn request(
+  method: Method,
+  host: String,
+  port: Option(Int),
+  path: String,
+  query: Option(String),
+) -> Request(Nil) {
   Message(
     head: RequestHead(method, host, port, path, query),
     headers: [],
@@ -178,6 +184,12 @@ pub fn get_header(
 ) -> Result(String, Nil) {
   let Message(headers: headers, ..) = message
   list.key_find(headers, string.lowercase(key))
+}
+
+/// Get all the headers fields
+pub fn get_headers(message: Message(head, body)) -> List(Header) {
+  let Message(headers: headers, ..) = message
+  headers
 }
 
 /// Set the value of a header field.

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -3,10 +3,8 @@
 //// This module makes it easy to create and modify Requests and Responses, data types.
 //// A general HTTP message type is defined that enables functions to work on both requests and responses.
 ////
-//// This module does not implement a HTTP client or HTTP server, but it can be as a base for them.
+//// This module does not implement a HTTP client or HTTP server, but it can be used as a base for them.
 
-import gleam/int
-import gleam/string_builder.{StringBuilder}
 import gleam/list
 import gleam/option.{None, Option, Some}
 import gleam/string
@@ -25,10 +23,8 @@ pub type Method {
   Options
   Patch
 
-  Other(
-    /// Non-standard but valid HTTP methods.
-    String,
-  )
+  /// Non-standard but valid HTTP methods.
+  Other(String)
 }
 
 // TODO: check if the a is a valid HTTP method (i.e. it is a token, as per the

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -1,8 +1,19 @@
-import gleam/string
+//// Functions for working with HTTP data structures in Gleam.
+////
+//// This module makes it easy to create and modify Requests and Responses, data types.
+//// A general HTTP message type is defined that enables functions to work on both requests and responses.
+////
+//// This module does not implement a HTTP client or HTTP server, but it can be as a base for them.
 
-/// HTTP methods as defined by RFC 2616, and PATCH which is defined by RFC
-/// 5789.
-///
+import gleam/int
+import gleam/iodata.{Iodata}
+import gleam/list
+import gleam/option.{Option, Some, None}
+import gleam/string
+import gleam/uri
+
+/// HTTP standard method as defined by [RFC 2616](https://tools.ietf.org/html/rfc2616),
+/// and PATCH which is defined by [RFC 5789](https://tools.ietf.org/html/rfc5789).
 pub type Method {
   Get
   Post
@@ -52,3 +63,160 @@ pub fn method_to_string(method) {
 
 pub external fn method_from_erlang(anything) -> Result(Method, Nil) =
   "gleam_http_native" "method_from_erlang"
+
+
+/// Data type containing an attribute value pair that constitute an HTTP header.
+pub type Header =
+  tuple(String, String)
+
+/// A general data type that can be be parameterised as a `Request` or `Response`
+pub type Message(head, body) {
+  Message(head: head, headers: List(Header), body: body)
+}
+
+/// Data structure containing the deserialized components of an HTTP request start line.
+pub type RequestHead {
+  RequestHead(
+    method: Method,
+    host: String,
+    port: Option(Int),
+    path: String,
+    query: Option(String),
+  )
+}
+
+/// Data structure containing the deserialized components of an HTTP response status line.
+pub type ResponseHead {
+  ResponseHead(status: Int)
+}
+
+/// HTTP message type parameterised as a Request.
+pub type Request(body) =
+  Message(RequestHead, body)
+
+/// HTTP message type parameterised as a Response.
+pub type Response(body) =
+  Message(ResponseHead, body)
+
+/// Construct a `Request` type.
+///
+/// The provided `uri_string` should be an absolure uri, including the scheme and host.
+/// The body type of the returned request is `Nil`,
+/// and should be set with a call to `set_body`.
+pub fn request(method: Method, uri_string: String) -> Request(Nil) {
+  let Ok(
+    uri.Uri(host: Some(host), port: port, path: path, query: query, ..),
+  ) = uri.parse(uri_string)
+  Message(
+    head: RequestHead(method, host, port, path, query),
+    headers: [],
+    body: Nil,
+  )
+}
+
+/// Construct a `Response` type.
+///
+/// The body type of the returned response is `Nil`,
+/// and should be set with a call to `set_body`.
+pub fn response(status: Int) -> Response(Nil) {
+  Message(head: ResponseHead(status), headers: [], body: Nil)
+}
+
+/// Get the method of a request.
+pub fn method(message: Message(RequestHead, body)) -> Method {
+  let Message(RequestHead(method: method, ..), ..) = message
+  method
+}
+
+/// Get the host of a request.
+pub fn host(message: Message(RequestHead, body)) -> String {
+  let Message(RequestHead(host: host, ..), ..) = message
+  host
+}
+
+/// Get the port of a request, if one was explicitly given.
+pub fn port(message: Message(RequestHead, body)) -> Option(Int) {
+  let Message(RequestHead(port: port, ..), ..) = message
+  port
+}
+
+/// Return the none-empty segments of a request path.
+pub fn path_segments(message: Message(RequestHead, body)) -> List(String) {
+  let Message(RequestHead(path: path, ..), ..) = message
+  uri.path_segments(path)
+}
+
+/// Decode the query from a request.
+pub fn get_query(
+  message: Message(RequestHead, body),
+) -> Result(List(tuple(String, String)), Nil) {
+  let Message(RequestHead(query: query_string, ..), ..) = message
+  case query_string {
+    Some(query_string) -> uri.parse_query(query_string)
+    None -> Ok([])
+  }
+}
+
+/// Get the value associated with a header field, if one was set.
+pub fn get_header(message: Message(head, body), key: String) -> Option(String) {
+  let Message(headers: headers, ..) = message
+  list.key_find(headers, string.lowercase(key))
+  |> option.from_result()
+}
+
+/// Set the value of a header field.
+pub fn set_header(
+  message: Message(head, body),
+  key: String,
+  value: String,
+) -> Message(head, body) {
+  let Message(head: head, headers: headers, body: body) = message
+  let headers = list.append(headers, [tuple(string.lowercase(key), value)])
+  Message(head: head, headers: headers, body: body)
+}
+
+/// Fetch the HTTP body as a string.
+///
+/// This method returns the body as a `String` for simplicity.
+/// Internally the body of HTTP messages is represented as `Iodata`.
+pub fn get_body(message: Message(head, Iodata)) -> String {
+  let Message(body: body, ..) = message
+  iodata.to_string(body)
+}
+
+/// Add the body to a HTTP message.
+pub fn set_body(
+  message: Message(head, Nil),
+  body: String,
+) -> Message(head, Iodata) {
+  let Message(head: head, headers: headers, body: _nil) = message
+  let body = iodata.from_strings([body])
+  let content_length = iodata.byte_size(body)
+  let headers = list.append(
+    headers,
+    [tuple("content-length", int.to_string(content_length))],
+  )
+  Message(head: head, headers: headers, body: body)
+}
+
+/// Fetch the body content decoded as a form.
+pub fn get_form(
+  message: Message(head, Iodata),
+) -> Result(List(tuple(String, String)), Nil) {
+  let Message(body: body, ..) = message
+  uri.parse_query(iodata.to_string(body))
+}
+
+/// Set the body serialized as a form.
+pub fn set_form(message, form) {
+  message
+  |> set_header("content-type", "application/x-www-form-urlencoded")
+  |> set_body(uri.query_to_string(form))
+}
+
+/// Create a response that redirects to the given uri.
+pub fn redirect(uri: String) -> Response(Iodata) {
+  response(303)
+  |> set_header("location", uri)
+  |> set_body("")
+}

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -8,7 +8,7 @@
 import gleam/int
 import gleam/string_builder.{StringBuilder}
 import gleam/list
-import gleam/option.{Option, Some, None}
+import gleam/option.{None, Option, Some}
 import gleam/string
 import gleam/uri.{Uri}
 
@@ -155,8 +155,8 @@ pub fn port(message: Message(RequestHead, body)) -> Option(Int) {
 
 /// Get the path of a request.
 pub fn path(message: Message(RequestHead, body)) -> String {
-    let Message(RequestHead(path: path, ..), ..) = message
-    path
+  let Message(RequestHead(path: path, ..), ..) = message
+  path
 }
 
 /// Return the none-empty segments of a request path.
@@ -178,12 +178,15 @@ pub fn get_query(
 
 /// Get the status of a response.
 pub fn status(message: Message(ResponseHead, body)) -> Int {
-    let Message(ResponseHead(status: status), ..) = message
-    status
+  let Message(ResponseHead(status: status), ..) = message
+  status
 }
 
 /// Get the value associated with a header field, if one was set.
-pub fn get_header(message: Message(head, body), key: String) -> Result(String, Nil) {
+pub fn get_header(
+  message: Message(head, body),
+  key: String,
+) -> Result(String, Nil) {
   let Message(headers: headers, ..) = message
   list.key_find(headers, string.lowercase(key))
 }

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -171,10 +171,9 @@ pub fn get_query(
 }
 
 /// Get the value associated with a header field, if one was set.
-pub fn get_header(message: Message(head, body), key: String) -> Option(String) {
+pub fn get_header(message: Message(head, body), key: String) -> Result(String, Nil) {
   let Message(headers: headers, ..) = message
   list.key_find(headers, string.lowercase(key))
-  |> option.from_result()
 }
 
 /// Set the value of a header field.

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -6,7 +6,7 @@
 //// This module does not implement a HTTP client or HTTP server, but it can be as a base for them.
 
 import gleam/int
-import gleam/iodata.{Iodata}
+import gleam/string_builder.{StringBuilder}
 import gleam/list
 import gleam/option.{Option, Some, None}
 import gleam/string
@@ -190,20 +190,20 @@ pub fn set_header(
 /// Fetch the HTTP body as a string.
 ///
 /// This method returns the body as a `String` for simplicity.
-/// Internally the body of HTTP messages is represented as `Iodata`.
-pub fn get_body(message: Message(head, Iodata)) -> String {
+/// Internally the body of HTTP messages is represented as `StringBuilder`.
+pub fn get_body(message: Message(head, StringBuilder)) -> String {
   let Message(body: body, ..) = message
-  iodata.to_string(body)
+  string_builder.to_string(body)
 }
 
 /// Add the body to a HTTP message.
 pub fn set_body(
   message: Message(head, Nil),
   body: String,
-) -> Message(head, Iodata) {
+) -> Message(head, StringBuilder) {
   let Message(head: head, headers: headers, body: _nil) = message
-  let body = iodata.from_strings([body])
-  let content_length = iodata.byte_size(body)
+  let body = string_builder.from_strings([body])
+  let content_length = string_builder.byte_size(body)
   let headers = list.append(
     headers,
     [tuple("content-length", int.to_string(content_length))],
@@ -213,10 +213,10 @@ pub fn set_body(
 
 /// Fetch the body content decoded as a form.
 pub fn get_form(
-  message: Message(head, Iodata),
+  message: Message(head, StringBuilder),
 ) -> Result(List(tuple(String, String)), Nil) {
   let Message(body: body, ..) = message
-  uri.parse_query(iodata.to_string(body))
+  uri.parse_query(string_builder.to_string(body))
 }
 
 /// Set the body serialized as a form.
@@ -227,7 +227,7 @@ pub fn set_form(message, form) {
 }
 
 /// Create a response that redirects to the given uri.
-pub fn redirect(uri: String) -> Response(Iodata) {
+pub fn redirect(uri: String) -> Response(StringBuilder) {
   response(303)
   |> set_header("location", uri)
   |> set_body("")

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -71,12 +71,12 @@ pub type Header =
   tuple(String, String)
 
 /// A general data type that can be be parameterised as a `Request` or `Response`
-pub type Message(head, body) {
+pub opaque type Message(head, body) {
   Message(head: head, headers: List(Header), body: body)
 }
 
 /// Data structure containing the deserialized components of an HTTP request start line.
-pub type RequestHead {
+pub opaque type RequestHead {
   RequestHead(
     method: Method,
     host: String,
@@ -87,7 +87,7 @@ pub type RequestHead {
 }
 
 /// Data structure containing the deserialized components of an HTTP response status line.
-pub type ResponseHead {
+pub opaque type ResponseHead {
   ResponseHead(status: Int)
 }
 
@@ -153,6 +153,12 @@ pub fn port(message: Message(RequestHead, body)) -> Option(Int) {
   port
 }
 
+/// Get the path of a request.
+pub fn path(message: Message(RequestHead, body)) -> String {
+    let Message(RequestHead(path: path, ..), ..) = message
+    path
+}
+
 /// Return the none-empty segments of a request path.
 pub fn path_segments(message: Message(RequestHead, body)) -> List(String) {
   let Message(RequestHead(path: path, ..), ..) = message
@@ -168,6 +174,12 @@ pub fn get_query(
     Some(query_string) -> uri.parse_query(query_string)
     None -> Ok([])
   }
+}
+
+/// Get the status of a response.
+pub fn status(message: Message(ResponseHead, body)) -> Int {
+    let Message(ResponseHead(status: status), ..) = message
+    status
 }
 
 /// Get the value associated with a header field, if one was set.

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -203,46 +203,19 @@ pub fn set_header(
 }
 
 /// Fetch the HTTP body as a string.
-///
-/// This method returns the body as a `String` for simplicity.
-/// Internally the body of HTTP messages is represented as `StringBuilder`.
-pub fn get_body(message: Message(head, StringBuilder)) -> String {
+pub fn get_body(message: Message(head, t)) -> t {
   let Message(body: body, ..) = message
-  string_builder.to_string(body)
+  body
 }
 
 /// Add the body to a HTTP message.
-pub fn set_body(
-  message: Message(head, Nil),
-  body: String,
-) -> Message(head, StringBuilder) {
+pub fn set_body(message: Message(head, Nil), body: t) -> Message(head, t) {
   let Message(head: head, headers: headers, body: _nil) = message
-  let body = string_builder.from_strings([body])
-  let content_length = string_builder.byte_size(body)
-  let headers = list.append(
-    headers,
-    [tuple("content-length", int.to_string(content_length))],
-  )
   Message(head: head, headers: headers, body: body)
 }
 
-/// Fetch the body content decoded as a form.
-pub fn get_form(
-  message: Message(head, StringBuilder),
-) -> Result(List(tuple(String, String)), Nil) {
-  let Message(body: body, ..) = message
-  uri.parse_query(string_builder.to_string(body))
-}
-
-/// Set the body serialized as a form.
-pub fn set_form(message, form) {
-  message
-  |> set_header("content-type", "application/x-www-form-urlencoded")
-  |> set_body(uri.query_to_string(form))
-}
-
 /// Create a response that redirects to the given uri.
-pub fn redirect(uri: String) -> Response(StringBuilder) {
+pub fn redirect(uri: String) -> Response(String) {
   response(303)
   |> set_header("location", uri)
   |> set_body("")

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -10,7 +10,7 @@ import gleam/iodata.{Iodata}
 import gleam/list
 import gleam/option.{Option, Some, None}
 import gleam/string
-import gleam/uri
+import gleam/uri.{Uri}
 
 /// HTTP standard method as defined by [RFC 2616](https://tools.ietf.org/html/rfc2616),
 /// and PATCH which is defined by [RFC 5789](https://tools.ietf.org/html/rfc5789).
@@ -25,8 +25,10 @@ pub type Method {
   Options
   Patch
 
-  /// Non-standard but valid HTTP methods.
-  Other(String)
+  Other(
+    /// Non-standard but valid HTTP methods.
+    String,
+  )
 }
 
 // TODO: check if the a is a valid HTTP method (i.e. it is a token, as per the
@@ -63,7 +65,6 @@ pub fn method_to_string(method) {
 
 pub external fn method_from_erlang(anything) -> Result(Method, Nil) =
   "gleam_http_native" "method_from_erlang"
-
 
 /// Data type containing an attribute value pair that constitute an HTTP header.
 pub type Header =
@@ -112,6 +113,18 @@ pub fn request(method: Method, uri_string: String) -> Request(Nil) {
     headers: [],
     body: Nil,
   )
+}
+
+/// Return the uri that a request was sent to.
+///
+pub fn request_uri(request: Request(a), secure: Bool) -> Uri {
+  let scheme = case secure {
+    True -> "https"
+    False -> "http"
+  }
+
+  let Message(head: RequestHead(_, host, port, path, query), ..) = request
+  Uri(Some(scheme), None, Some(host), port, path, query, None)
 }
 
 /// Construct a `Response` type.

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -96,14 +96,7 @@ pub type Response(body) =
   Message(ResponseHead, body)
 
 /// Construct a `Request` type.
-///
-/// The provided `uri_string` should be an absolure uri, including the scheme and host.
-/// The body type of the returned request is `Nil`,
-/// and should be set with a call to `set_body`.
-pub fn request(method: Method, uri_string: String) -> Request(Nil) {
-  let Ok(
-    uri.Uri(host: Some(host), port: port, path: path, query: query, ..),
-  ) = uri.parse(uri_string)
+pub fn request(method: Method, host: String, port: Option(Int), path: String, query: Option(String)) -> Request(Nil) {
   Message(
     head: RequestHead(method, host, port, path, query),
     headers: [],

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -602,35 +602,12 @@ pub fn header_test() {
   should.equal(Ok("x"), http.get_header(message, "X-Foo"))
   should.equal(Error(Nil), http.get_header(message, "x-bar"))
 }
-// pub fn set_body_test() {
-//   let message = Message(Nil, [], Nil)
-//     |> http.set_body("Hello, World!")
-//
-//   should.equal(Ok("13"), http.get_header(message, "content-length"))
-// }
-//
-// pub fn get_body_test() {
-//   let message = Message(Nil, [], string_builder.from_strings(["Hello, ", "World!"]))
-//
-//   should.equal("Hello, World!", http.get_body(message))
-// }
-//
-// pub fn set_form_test() {
-//   let message = Message(Nil, [], Nil)
-//     |> http.set_form([tuple("foo", "x y"), tuple("bar", "%&")])
-//
-//   should.equal("foo=x+y&bar=%25%26", string_builder.to_string(message.body))
-//   should.equal(
-//     Ok("application/x-www-form-urlencoded"),
-//     http.get_header(message, "content-type"),
-//   )
-// }
-//
-// pub fn get_form_test() {
-//   let message = Message(Nil, [], string_builder.from_strings(["foo=x+y&bar=%25%26"]))
-//
-//   should.equal(
-//     Ok([tuple("foo", "x y"), tuple("bar", "%&")]),
-//     http.get_form(message),
-//   )
-// }
+
+pub fn body_test() {
+  let message = http.response(200)
+    |> http.set_body("Hello, World!")
+
+  message
+  |> http.get_body
+  |> should.equal("Hello, World!")
+}

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -575,7 +575,7 @@ pub fn redirect_test() {
   let response = http.redirect("/other")
 
   should.equal(303, response.head.status)
-  should.equal(Some("/other"), http.get_header(response, "location"))
+  should.equal(Ok("/other"), http.get_header(response, "location"))
 }
 
 pub fn path_segments_test() {
@@ -597,9 +597,9 @@ pub fn get_query_test() {
 pub fn get_header_test() {
   let message = Message(Nil, [tuple("x-foo", "x")], Nil)
 
-  should.equal(Some("x"), http.get_header(message, "x-foo"))
-  should.equal(Some("x"), http.get_header(message, "X-Foo"))
-  should.equal(None, http.get_header(message, "x-bar"))
+  should.equal(Ok("x"), http.get_header(message, "x-foo"))
+  should.equal(Ok("x"), http.get_header(message, "X-Foo"))
+  should.equal(Error(Nil), http.get_header(message, "x-bar"))
 }
 
 pub fn set_header_test() {
@@ -619,7 +619,7 @@ pub fn set_body_test() {
   let message = Message(Nil, [], Nil)
     |> http.set_body("Hello, World!")
 
-  should.equal(Some("13"), http.get_header(message, "content-length"))
+  should.equal(Ok("13"), http.get_header(message, "content-length"))
 }
 
 pub fn get_body_test() {
@@ -634,7 +634,7 @@ pub fn set_form_test() {
 
   should.equal("foo=x+y&bar=%25%26", iodata.to_string(message.body))
   should.equal(
-    Some("application/x-www-form-urlencoded"),
+    Ok("application/x-www-form-urlencoded"),
     http.get_header(message, "content-type"),
   )
 }

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -1,10 +1,10 @@
 import gleam/atom
 import gleam/iodata
+import gleam/uri.{Uri}
 import gleam/http
 import gleam/http.{Message, Get}
 import gleam/option.{Some, None}
 import gleam/should
-
 
 pub fn parse_method_test() {
   "Connect"
@@ -561,6 +561,14 @@ pub fn method_to_string_test() {
   http.Other("nope")
   |> http.method_to_string
   |> should.equal("nope")
+}
+
+pub fn request_uri_test() {
+  let request = http.request(Get, "//example.com/foo/bar")
+  http.request_uri(request, True)
+  |> should.equal(
+    Uri(Some("https"), None, Some("example.com"), None, "/foo/bar", None, None),
+  )
 }
 
 pub fn redirect_test() {

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -1,6 +1,10 @@
-import gleam/should
 import gleam/atom
+import gleam/iodata
 import gleam/http
+import gleam/http.{Message, Get}
+import gleam/option.{Some, None}
+import gleam/should
+
 
 pub fn parse_method_test() {
   "Connect"
@@ -557,4 +561,81 @@ pub fn method_to_string_test() {
   http.Other("nope")
   |> http.method_to_string
   |> should.equal("nope")
+}
+
+pub fn redirect_test() {
+  let response = http.redirect("/other")
+
+  should.equal(303, response.head.status)
+  should.equal(Some("/other"), http.get_header(response, "location"))
+}
+
+pub fn path_segments_test() {
+  let request = http.request(Get, "//example.com/foo/bar")
+  should.equal(["foo", "bar"], http.path_segments(request))
+}
+
+pub fn get_query_test() {
+  let request = http.request(Get, "//example.com/?foo=x%20y")
+  should.equal(Ok([tuple("foo", "x y")]), http.get_query(request))
+
+  let request = http.request(Get, "//example.com/")
+  should.equal(Ok([]), http.get_query(request))
+
+  let request = http.request(Get, "//example.com/?foo=%!2")
+  should.equal(Error(Nil), http.get_query(request))
+}
+
+pub fn get_header_test() {
+  let message = Message(Nil, [tuple("x-foo", "x")], Nil)
+
+  should.equal(Some("x"), http.get_header(message, "x-foo"))
+  should.equal(Some("x"), http.get_header(message, "X-Foo"))
+  should.equal(None, http.get_header(message, "x-bar"))
+}
+
+pub fn set_header_test() {
+  let message = Message(Nil, [], Nil)
+
+  should.equal(
+    [tuple("x-foo", "x")],
+    http.set_header(message, "x-foo", "x").headers,
+  )
+  should.equal(
+    [tuple("x-foo", "x")],
+    http.set_header(message, "X-Foo", "x").headers,
+  )
+}
+
+pub fn set_body_test() {
+  let message = Message(Nil, [], Nil)
+    |> http.set_body("Hello, World!")
+
+  should.equal(Some("13"), http.get_header(message, "content-length"))
+}
+
+pub fn get_body_test() {
+  let message = Message(Nil, [], iodata.from_strings(["Hello, ", "World!"]))
+
+  should.equal("Hello, World!", http.get_body(message))
+}
+
+pub fn set_form_test() {
+  let message = Message(Nil, [], Nil)
+    |> http.set_form([tuple("foo", "x y"), tuple("bar", "%&")])
+
+  should.equal("foo=x+y&bar=%25%26", iodata.to_string(message.body))
+  should.equal(
+    Some("application/x-www-form-urlencoded"),
+    http.get_header(message, "content-type"),
+  )
+}
+
+pub fn get_form_test() {
+  let message = Message(Nil, [], iodata.from_strings(["foo=x+y&bar=%25%26"]))
+
+  should.equal(
+    Ok([tuple("foo", "x y"), tuple("bar", "%&")]),
+    http.get_form(message),
+  )
 }

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -597,10 +597,13 @@ pub fn get_query_test() {
 pub fn header_test() {
   let message = http.response(200)
     |> http.set_header("x-foo", "x")
+    |> http.set_header("x-BAR", "y")
 
   should.equal(Ok("x"), http.get_header(message, "x-foo"))
   should.equal(Ok("x"), http.get_header(message, "X-Foo"))
-  should.equal(Error(Nil), http.get_header(message, "x-bar"))
+  should.equal(Error(Nil), http.get_header(message, "x-baz"))
+  http.get_headers(message)
+  |> should.equal([tuple("x-foo", "x"), tuple("x-bar", "y")])
 }
 
 pub fn body_test() {

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -2,7 +2,7 @@ import gleam/atom
 import gleam/string_builder
 import gleam/uri.{Uri}
 import gleam/http
-import gleam/http.{Message, Get}
+import gleam/http.{Get}
 import gleam/option.{Some, None}
 import gleam/should
 
@@ -574,7 +574,7 @@ pub fn request_uri_test() {
 pub fn redirect_test() {
   let response = http.redirect("/other")
 
-  should.equal(303, response.head.status)
+  should.equal(303, http.status(response))
   should.equal(Ok("/other"), http.get_header(response, "location"))
 }
 
@@ -594,56 +594,45 @@ pub fn get_query_test() {
   should.equal(Error(Nil), http.get_query(request))
 }
 
-pub fn get_header_test() {
-  let message = Message(Nil, [tuple("x-foo", "x")], Nil)
+pub fn header_test() {
+  let message = http.response(200)
+  |> http.set_header("x-foo", "x")
 
   should.equal(Ok("x"), http.get_header(message, "x-foo"))
   should.equal(Ok("x"), http.get_header(message, "X-Foo"))
   should.equal(Error(Nil), http.get_header(message, "x-bar"))
 }
 
-pub fn set_header_test() {
-  let message = Message(Nil, [], Nil)
 
-  should.equal(
-    [tuple("x-foo", "x")],
-    http.set_header(message, "x-foo", "x").headers,
-  )
-  should.equal(
-    [tuple("x-foo", "x")],
-    http.set_header(message, "X-Foo", "x").headers,
-  )
-}
-
-pub fn set_body_test() {
-  let message = Message(Nil, [], Nil)
-    |> http.set_body("Hello, World!")
-
-  should.equal(Ok("13"), http.get_header(message, "content-length"))
-}
-
-pub fn get_body_test() {
-  let message = Message(Nil, [], string_builder.from_strings(["Hello, ", "World!"]))
-
-  should.equal("Hello, World!", http.get_body(message))
-}
-
-pub fn set_form_test() {
-  let message = Message(Nil, [], Nil)
-    |> http.set_form([tuple("foo", "x y"), tuple("bar", "%&")])
-
-  should.equal("foo=x+y&bar=%25%26", string_builder.to_string(message.body))
-  should.equal(
-    Ok("application/x-www-form-urlencoded"),
-    http.get_header(message, "content-type"),
-  )
-}
-
-pub fn get_form_test() {
-  let message = Message(Nil, [], string_builder.from_strings(["foo=x+y&bar=%25%26"]))
-
-  should.equal(
-    Ok([tuple("foo", "x y"), tuple("bar", "%&")]),
-    http.get_form(message),
-  )
-}
+// pub fn set_body_test() {
+//   let message = Message(Nil, [], Nil)
+//     |> http.set_body("Hello, World!")
+//
+//   should.equal(Ok("13"), http.get_header(message, "content-length"))
+// }
+//
+// pub fn get_body_test() {
+//   let message = Message(Nil, [], string_builder.from_strings(["Hello, ", "World!"]))
+//
+//   should.equal("Hello, World!", http.get_body(message))
+// }
+//
+// pub fn set_form_test() {
+//   let message = Message(Nil, [], Nil)
+//     |> http.set_form([tuple("foo", "x y"), tuple("bar", "%&")])
+//
+//   should.equal("foo=x+y&bar=%25%26", string_builder.to_string(message.body))
+//   should.equal(
+//     Ok("application/x-www-form-urlencoded"),
+//     http.get_header(message, "content-type"),
+//   )
+// }
+//
+// pub fn get_form_test() {
+//   let message = Message(Nil, [], string_builder.from_strings(["foo=x+y&bar=%25%26"]))
+//
+//   should.equal(
+//     Ok([tuple("foo", "x y"), tuple("bar", "%&")]),
+//     http.get_form(message),
+//   )
+// }

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -1,5 +1,5 @@
 import gleam/atom
-import gleam/iodata
+import gleam/string_builder
 import gleam/uri.{Uri}
 import gleam/http
 import gleam/http.{Message, Get}
@@ -623,7 +623,7 @@ pub fn set_body_test() {
 }
 
 pub fn get_body_test() {
-  let message = Message(Nil, [], iodata.from_strings(["Hello, ", "World!"]))
+  let message = Message(Nil, [], string_builder.from_strings(["Hello, ", "World!"]))
 
   should.equal("Hello, World!", http.get_body(message))
 }
@@ -632,7 +632,7 @@ pub fn set_form_test() {
   let message = Message(Nil, [], Nil)
     |> http.set_form([tuple("foo", "x y"), tuple("bar", "%&")])
 
-  should.equal("foo=x+y&bar=%25%26", iodata.to_string(message.body))
+  should.equal("foo=x+y&bar=%25%26", string_builder.to_string(message.body))
   should.equal(
     Ok("application/x-www-form-urlencoded"),
     http.get_header(message, "content-type"),
@@ -640,7 +640,7 @@ pub fn set_form_test() {
 }
 
 pub fn get_form_test() {
-  let message = Message(Nil, [], iodata.from_strings(["foo=x+y&bar=%25%26"]))
+  let message = Message(Nil, [], string_builder.from_strings(["foo=x+y&bar=%25%26"]))
 
   should.equal(
     Ok([tuple("foo", "x y"), tuple("bar", "%&")]),

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -564,7 +564,7 @@ pub fn method_to_string_test() {
 }
 
 pub fn request_uri_test() {
-  let request = http.request(Get, "//example.com/foo/bar")
+  let request = http.request(Get, "example.com", None, "/foo/bar", None)
   http.request_uri(request, True)
   |> should.equal(
     Uri(Some("https"), None, Some("example.com"), None, "/foo/bar", None, None),
@@ -579,18 +579,18 @@ pub fn redirect_test() {
 }
 
 pub fn path_segments_test() {
-  let request = http.request(Get, "//example.com/foo/bar")
+  let request = http.request(Get, "example.com", None, "/foo/bar", None)
   should.equal(["foo", "bar"], http.path_segments(request))
 }
 
 pub fn get_query_test() {
-  let request = http.request(Get, "//example.com/?foo=x%20y")
+  let request = http.request(Get, "example.com", None, "/", Some("foo=x%20y"))
   should.equal(Ok([tuple("foo", "x y")]), http.get_query(request))
 
-  let request = http.request(Get, "//example.com/")
+  let request = http.request(Get, "example.com", None, "/", None)
   should.equal(Ok([]), http.get_query(request))
 
-  let request = http.request(Get, "//example.com/?foo=%!2")
+  let request = http.request(Get, "example.com", None, "/", Some("foo=%!2"))
   should.equal(Error(Nil), http.get_query(request))
 }
 

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -3,7 +3,7 @@ import gleam/string_builder
 import gleam/uri.{Uri}
 import gleam/http
 import gleam/http.{Get}
-import gleam/option.{Some, None}
+import gleam/option.{None, Some}
 import gleam/should
 
 pub fn parse_method_test() {
@@ -596,14 +596,12 @@ pub fn get_query_test() {
 
 pub fn header_test() {
   let message = http.response(200)
-  |> http.set_header("x-foo", "x")
+    |> http.set_header("x-foo", "x")
 
   should.equal(Ok("x"), http.get_header(message, "x-foo"))
   should.equal(Ok("x"), http.get_header(message, "X-Foo"))
   should.equal(Error(Nil), http.get_header(message, "x-bar"))
 }
-
-
 // pub fn set_body_test() {
 //   let message = Message(Nil, [], Nil)
 //     |> http.set_body("Hello, World!")


### PR DESCRIPTION
This is what I have been up to with HTTP data types.

I know this is well beyond the scope of what you currently have planned for gleam HTTP. But I thought it might be interesting for some looking into gleam and HTTP
I'm unconvinced, though willing to be convinced, that a http library that defines only the request verbs is particularly useful, Certainly I wanted more in a common library that I could use between midas and magpie. The common library that defined full HTTP message could be built on top of the verbs only library for sure, but one would likely become a defacto standard.

I've tried to keep this library fairly un-prescriptive. The body in the datastructure is parameterisable so that you could still use them  to hold headers etc as you expect but potententially use an iteratior for the body to handle streaming etc. (although some helper functions assume it's an iolist) 

My opinion (strong opinion loosely held I hope) is that it would be useful to have this much that is common between libraries that work with HTTP. 
