### PR TITLE
Add more unit tests

### DIFF
--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -417,7 +417,6 @@ pub fn default_req() -> Request(BitString) {
   )
 }
 
-// TODO: test
 // TODO: record update syntax
 /// Set the method of the request.
 ///

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -204,7 +204,6 @@ pub fn get_query(
   }
 }
 
-// TODO: test
 // TODO: escape
 // TODO: record update syntax
 /// Set the query of the request.
@@ -268,7 +267,6 @@ pub fn get_resp_header(
 
 // TODO: use record update syntax
 // TODO: document
-// TODO: test
 // https://github.com/elixir-plug/plug/blob/dfebbebeb716c43c7dee4915a061bede06ec45f1/lib/plug/conn.ex#L809
 pub fn prepend_req_header(
   request: Request(body),
@@ -303,7 +301,6 @@ pub fn set_resp_body(
   Response(status: status, headers: headers, body: body)
 }
 
-// TODO: test
 // TODO: record update syntax
 /// Set the body of the request, overwriting any existing body.
 ///

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -356,7 +356,6 @@ pub fn set_method(req: Request(body), method: Method) -> Request(body) {
   )
 }
 
-// TODO: test
 /// Update the body of a response using a given function.
 ///
 pub fn map_resp_body(

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -378,7 +378,6 @@ pub fn map_req_body(
   |> set_req_body(request, _)
 }
 
-// TODO: test
 /// Update the body of a response using a given result returning function.
 ///
 /// If the given function returns an `Ok` value the body is set, if it returns

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -443,7 +443,6 @@ pub fn set_host(req: Request(body), host: String) -> Request(body) {
   )
 }
 
-// TODO: test
 // TODO: record update syntax
 /// Set the path of the request.
 ///

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -401,7 +401,7 @@ pub fn redirect(uri: String) -> Response(String) {
   )
 }
 
-/// A request with commonly used default values. This request can be used as a
+/// A request with commonly used default values. This request can be used as
 /// an initial value and then update to create the desired request.
 ///
 pub fn default_req() -> Request(BitString) {

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -367,7 +367,6 @@ pub fn map_resp_body(
   |> set_resp_body(response, _)
 }
 
-// TODO: test
 /// Update the body of a request using a given function.
 ///
 pub fn map_req_body(

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -330,7 +330,6 @@ pub fn set_req_body(
   )
 }
 
-// TODO: test
 // TODO: record update syntax
 /// Set the method of the request.
 ///

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -912,12 +912,26 @@ pub fn set_host_test() {
   original_request.host
   |> should.equal("localhost")
 
-  let updated_request = http.default_req()
+  let updated_request = original_request
   |> http.set_host(new_host)
 
   // host should be updated
   updated_request.host
   |> should.equal(new_host)
+}
+
+pub fn set_path_test() {
+  let new_path = "/gleam-lang"
+  let original_request = http.default_req()
+  original_request.path
+  |> should.equal("")
+
+  let updated_request = original_request
+  |> http.set_path(new_path)
+
+  // path should be updated
+  updated_request.path
+  |> should.equal("/gleam-lang")
 }
 
 pub fn get_resp_header_test() {

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -892,6 +892,20 @@ pub fn try_map_resp_body_test() {
   |> should.equal(Error("transform failure"))
 }
 
+pub fn default_request_test() {
+  http.default_req()
+  |> should.equal(http.Request(
+    method: http.Get,
+    headers: [],
+    body: <<>>,
+    scheme: http.Https,
+    host: "localhost",
+    port: None,
+    path: "",
+    query: None,
+  ))
+}
+
 pub fn get_resp_header_test() {
   let response = http.response(200)
     |> http.prepend_resp_header("x-foo", "x")

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -6,6 +6,7 @@ import gleam/uri.{Uri}
 import gleam/http.{Http, Https}
 import gleam/option.{None, Some}
 import gleam/should
+import gleam/result
 
 pub fn parse_method_test() {
   "Connect"
@@ -871,6 +872,24 @@ pub fn map_req_body_test() {
 
   updated_request.body
   |> should.equal(expected_updated_body)
+}
+
+pub fn try_map_resp_body_test() {
+  let transform = fn(old_body) {
+    Ok("new body")
+  }
+
+  let response = http.response(200)
+  http.try_map_resp_body(response, transform)
+  |> should.equal(Ok(http.Response(200, [], "new body")))
+
+  // transform function which fails should propogate error
+  let transform_failure = fn(old_body) {
+    Error("transform failure")
+  }
+
+  http.try_map_resp_body(response, transform_failure)
+  |> should.equal(Error("transform failure"))
 }
 
 pub fn get_resp_header_test() {

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -766,6 +766,34 @@ pub fn set_query_test() {
   |> should.equal(Some(""))
 }
 
+pub fn get_req_header_test() {
+  let make_request = fn(headers) {
+    http.Request(
+      method: http.Get,
+      headers: headers,
+      body: Nil,
+      scheme: http.Https,
+      host: "example.com",
+      port: None,
+      path: "/",
+      query: None,
+    )
+  }
+
+  let header_key = "GLEAM"
+  let request = make_request([tuple("answer", "42"), tuple("gleam", "awesome")])
+  should.equal(
+    Ok("awesome"),
+    request
+    |> http.get_req_header(header_key))
+
+  let request = make_request([tuple("answer", "42")])
+  should.equal(
+    Error(Nil),
+    request
+    |> http.get_req_header(header_key))
+}
+
 pub fn get_resp_header_test() {
   let response = http.response(200)
     |> http.prepend_resp_header("x-foo", "x")

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -842,22 +842,34 @@ pub fn set_method_test() {
   |> should.equal(http.Post)
 }
 
-pub fn map_resp_body_test() {
-  let map_body = fn(old_body: String) {
-    string.reverse(old_body)
-  }
+fn reverse_body(old_body: String) {
+  string.reverse(old_body)
+}
 
+pub fn map_resp_body_test() {
   let response = http.Response(
     status: 200,
     headers: [],
     body: "abcd"
   )
+  
   let expected_updated_body = "dcba"
-
   let updated_response = response
-  |> http.map_resp_body(map_body)
+  |> http.map_resp_body(reverse_body)
 
   updated_response.body
+  |> should.equal(expected_updated_body)
+}
+
+pub fn map_req_body_test() {
+  let request = http.default_req()
+  |> http.set_req_body("abcd")
+
+  let expected_updated_body = "dcba"
+  let updated_request = request
+  |> http.map_req_body(reverse_body)
+
+  updated_request.body
   |> should.equal(expected_updated_body)
 }
 

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -906,6 +906,20 @@ pub fn default_request_test() {
   ))
 }
 
+pub fn set_host_test() {
+  let new_host = "github"
+  let original_request = http.default_req()
+  original_request.host
+  |> should.equal("localhost")
+
+  let updated_request = http.default_req()
+  |> http.set_host(new_host)
+
+  // host should be updated
+  updated_request.host
+  |> should.equal(new_host)
+}
+
 pub fn get_resp_header_test() {
   let response = http.response(200)
     |> http.prepend_resp_header("x-foo", "x")

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -794,6 +794,33 @@ pub fn get_req_header_test() {
     |> http.get_req_header(header_key))
 }
 
+pub fn set_req_body_test() {
+  let body = """
+    <html>
+      <body>
+        <title>Gleam is the best!</title>
+      </body>
+    </html>
+  """
+
+  let request = http.Request(
+    method: http.Get,
+    headers: [],
+    body: Nil,
+    scheme: http.Https,
+    host: "example.com",
+    port: None,
+    path: "/",
+    query: None,
+  )
+
+  let updated_request = request
+   |> http.set_req_body(body)
+
+  updated_request.body
+  |> should.equal(body)
+}
+
 pub fn get_resp_header_test() {
   let response = http.response(200)
     |> http.prepend_resp_header("x-foo", "x")
@@ -864,6 +891,7 @@ pub fn prepend_req_header_test() {
   let request = request
   |> http.prepend_req_header("gleam", "awesome")
 
+  // request should have two headers now
   request.headers
   |> should.equal([tuple("gleam", "awesome"), tuple("answer", "42"),])
 }

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -676,6 +676,27 @@ pub fn req_to_uri_test() {
   )
 }
 
+pub fn req_from_uri_test() {
+  let uri = Uri(Some("https"), None, Some("sky.net"), None, "/sarah/connor", None, None)
+ 
+  uri
+  |> http.req_from_uri
+  |> should.equal(
+    Ok(
+      http.Request(
+        method: http.Get,
+        headers: [],
+        body: "",
+        scheme: http.Https,
+        host: "sky.net",
+        port: None,
+        path: "/sarah/connor",
+        query: None
+      )
+    )
+  )
+}
+
 pub fn redirect_test() {
   let response = http.redirect("/other")
 

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -821,6 +821,26 @@ pub fn set_req_body_test() {
   |> should.equal(body)
 }
 
+pub fn set_method_test() {
+  let request = http.Request(
+    method: http.Get,
+    headers: [],
+    body: "",
+    scheme: http.Https,
+    host: "example.com",
+    port: None,
+    path: "/",
+    query: None
+  )
+
+  let updated_request_method = http.Post
+  let updated_request = request
+  |> http.set_method(updated_request_method)
+
+  updated_request.method
+  |> should.equal(http.Post)
+}
+
 pub fn get_resp_header_test() {
   let response = http.response(200)
     |> http.prepend_resp_header("x-foo", "x")

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -743,6 +743,29 @@ pub fn get_query_test() {
   should.equal(Error(Nil), http.get_query(request))
 }
 
+pub fn set_query_test() {
+  let request = http.Request(
+    method: http.Get,
+    headers: [],
+    body: Nil,
+    scheme: http.Https,
+    host: "example.com",
+    port: None,
+    path: "/",
+    query: None,
+  )
+
+  let query = [tuple("answer", "42"), tuple("test", "123")]
+  let updated_request = http.set_query(request, query)
+  updated_request.query
+  |> should.equal(Some("answer=42&test=123"))
+
+  let empty_query = []
+  let updated_request = http.set_query(request, empty_query)
+  updated_request.query
+  |> should.equal(Some(""))
+}
+
 pub fn get_resp_header_test() {
   let response = http.response(200)
     |> http.prepend_resp_header("x-foo", "x")

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -1,6 +1,7 @@
 import gleam/atom
 import gleam/dynamic
 import gleam/string_builder
+import gleam/string
 import gleam/uri.{Uri}
 import gleam/http.{Http, Https}
 import gleam/option.{None, Some}
@@ -839,6 +840,25 @@ pub fn set_method_test() {
 
   updated_request.method
   |> should.equal(http.Post)
+}
+
+pub fn map_resp_body_test() {
+  let map_body = fn(old_body: String) {
+    string.reverse(old_body)
+  }
+
+  let response = http.Response(
+    status: 200,
+    headers: [],
+    body: "abcd"
+  )
+  let expected_updated_body = "dcba"
+
+  let updated_response = response
+  |> http.map_resp_body(map_body)
+
+  updated_response.body
+  |> should.equal(expected_updated_body)
 }
 
 pub fn get_resp_header_test() {

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -679,8 +679,15 @@ pub fn req_to_uri_test() {
 }
 
 pub fn req_from_uri_test() {
-  let uri = Uri(Some("https"), None, Some("sky.net"), None, "/sarah/connor", None, None)
- 
+  let uri = Uri(
+    Some("https"),
+    None,
+    Some("sky.net"),
+    None,
+    "/sarah/connor",
+    None,
+    None,
+  )
   uri
   |> http.req_from_uri
   |> should.equal(
@@ -693,9 +700,9 @@ pub fn req_from_uri_test() {
         host: "sky.net",
         port: None,
         path: "/sarah/connor",
-        query: None
-      )
-    )
+        query: None,
+      ),
+    ),
   )
 }
 
@@ -784,26 +791,26 @@ pub fn get_req_header_test() {
 
   let header_key = "GLEAM"
   let request = make_request([tuple("answer", "42"), tuple("gleam", "awesome")])
-  should.equal(
-    Ok("awesome"),
-    request
-    |> http.get_req_header(header_key))
+  request
+  |> http.get_req_header(header_key)
+  |> should.equal(Ok("awesome"))
 
   let request = make_request([tuple("answer", "42")])
-  should.equal(
-    Error(Nil),
-    request
-    |> http.get_req_header(header_key))
+  request
+  |> http.get_req_header(header_key)
+  |> should.equal(Error(Nil))
 }
 
 pub fn set_req_body_test() {
-  let body = """
+  let body = ""
+  "
     <html>
       <body>
         <title>Gleam is the best!</title>
       </body>
     </html>
-  """
+  "
+  ""
 
   let request = http.Request(
     method: http.Get,
@@ -817,7 +824,7 @@ pub fn set_req_body_test() {
   )
 
   let updated_request = request
-   |> http.set_req_body(body)
+    |> http.set_req_body(body)
 
   updated_request.body
   |> should.equal(body)
@@ -832,12 +839,12 @@ pub fn set_method_test() {
     host: "example.com",
     port: None,
     path: "/",
-    query: None
+    query: None,
   )
 
   let updated_request_method = http.Post
   let updated_request = request
-  |> http.set_method(updated_request_method)
+    |> http.set_method(updated_request_method)
 
   updated_request.method
   |> should.equal(http.Post)
@@ -848,15 +855,10 @@ fn reverse_body(old_body: String) {
 }
 
 pub fn map_resp_body_test() {
-  let response = http.Response(
-    status: 200,
-    headers: [],
-    body: "abcd"
-  )
-  
+  let response = http.Response(status: 200, headers: [], body: "abcd")
   let expected_updated_body = "dcba"
   let updated_response = response
-  |> http.map_resp_body(reverse_body)
+    |> http.map_resp_body(reverse_body)
 
   updated_response.body
   |> should.equal(expected_updated_body)
@@ -864,29 +866,25 @@ pub fn map_resp_body_test() {
 
 pub fn map_req_body_test() {
   let request = http.default_req()
-  |> http.set_req_body("abcd")
+    |> http.set_req_body("abcd")
 
   let expected_updated_body = "dcba"
   let updated_request = request
-  |> http.map_req_body(reverse_body)
+    |> http.map_req_body(reverse_body)
 
   updated_request.body
   |> should.equal(expected_updated_body)
 }
 
 pub fn try_map_resp_body_test() {
-  let transform = fn(old_body) {
-    Ok("new body")
-  }
+  let transform = fn(old_body) { Ok("new body") }
 
   let response = http.response(200)
   http.try_map_resp_body(response, transform)
   |> should.equal(Ok(http.Response(200, [], "new body")))
 
   // transform function which fails should propogate error
-  let transform_failure = fn(old_body) {
-    Error("transform failure")
-  }
+  let transform_failure = fn(old_body) { Error("transform failure") }
 
   http.try_map_resp_body(response, transform_failure)
   |> should.equal(Error("transform failure"))
@@ -894,16 +892,18 @@ pub fn try_map_resp_body_test() {
 
 pub fn default_request_test() {
   http.default_req()
-  |> should.equal(http.Request(
-    method: http.Get,
-    headers: [],
-    body: <<>>,
-    scheme: http.Https,
-    host: "localhost",
-    port: None,
-    path: "",
-    query: None,
-  ))
+  |> should.equal(
+    http.Request(
+      method: http.Get,
+      headers: [],
+      body: <<>>,
+      scheme: http.Https,
+      host: "localhost",
+      port: None,
+      path: "",
+      query: None,
+    ),
+  )
 }
 
 pub fn set_host_test() {
@@ -913,7 +913,7 @@ pub fn set_host_test() {
   |> should.equal("localhost")
 
   let updated_request = original_request
-  |> http.set_host(new_host)
+    |> http.set_host(new_host)
 
   // host should be updated
   updated_request.host
@@ -927,7 +927,7 @@ pub fn set_path_test() {
   |> should.equal("")
 
   let updated_request = original_request
-  |> http.set_path(new_path)
+    |> http.set_path(new_path)
 
   // path should be updated
   updated_request.path
@@ -987,26 +987,26 @@ pub fn scheme_from_string_test() {
 pub fn prepend_req_header_test() {
   let headers = []
   let request = http.Request(
-    method: http.Get,
-    headers: headers,
-    body: Nil,
-    scheme: http.Https,
-    host: "example.com",
-    port: None,
-    path: "/",
-    query: None
-  )
-  |> http.prepend_req_header("answer", "42")
+      method: http.Get,
+      headers: headers,
+      body: Nil,
+      scheme: http.Https,
+      host: "example.com",
+      port: None,
+      path: "/",
+      query: None,
+    )
+    |> http.prepend_req_header("answer", "42")
 
   request.headers
   |> should.equal([tuple("answer", "42")])
 
   let request = request
-  |> http.prepend_req_header("gleam", "awesome")
+    |> http.prepend_req_header("gleam", "awesome")
 
   // request should have two headers now
   request.headers
-  |> should.equal([tuple("gleam", "awesome"), tuple("answer", "42"),])
+  |> should.equal([tuple("gleam", "awesome"), tuple("answer", "42")])
 }
 
 pub fn get_req_cookies_test() {

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -844,6 +844,30 @@ pub fn scheme_from_string_test() {
   |> should.equal(Error(Nil))
 }
 
+pub fn prepend_req_header_test() {
+  let headers = []
+  let request = http.Request(
+    method: http.Get,
+    headers: headers,
+    body: Nil,
+    scheme: http.Https,
+    host: "example.com",
+    port: None,
+    path: "/",
+    query: None
+  )
+  |> http.prepend_req_header("answer", "42")
+
+  request.headers
+  |> should.equal([tuple("answer", "42")])
+
+  let request = request
+  |> http.prepend_req_header("gleam", "awesome")
+
+  request.headers
+  |> should.equal([tuple("gleam", "awesome"), tuple("answer", "42"),])
+}
+
 pub fn get_req_cookies_test() {
   http.default_req()
   |> http.prepend_req_header("cookie", "k1=v1; k2=v2")


### PR DESCRIPTION
# Overview

This PR is to add some more unit tests for the http module. This captures #13 .

## Tests added

In this PR tests for the following functions have been added:
- `req_from_uri`
- `set_query`
- `get_req_header`
- `prepend_req_header`
- `set_req_body`
- `set_method`
- `map_resp_body`
- `map_req_body`
- `try_map_resp_body`
- `default_req`
- `set_host`
- `set_path`