### PR TITLE
Default request has BitString body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.3.1 - TBC
+
+- The `gleam/http.default_req` function returns a `Request(BitString)` instead
+  `Request(String)`
+
 ## v1.3.0 - 2020-08-04
 
 - The `gleam/http/cookie` module has been merged into the `gleam/http` module.

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -411,11 +411,11 @@ pub fn redirect(uri: String) -> Response(String) {
 /// A request with commonly used default values. This request can be used as a
 /// an initial value and then update to create the desired request.
 ///
-pub fn default_req() -> Request(String) {
+pub fn default_req() -> Request(BitString) {
   Request(
     method: Get,
     headers: [],
-    body: "",
+    body: <<>>,
     scheme: Https,
     host: "localhost",
     port: None,


### PR DESCRIPTION
Request can have raw binaries not just utf8 strings. Also this is the Body type expected by the cowboy and elli examples