### PR TITLE
Update code to use new record update syntax

### DIFF
--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -160,21 +160,24 @@ pub fn req_to_uri(request: Request(a)) -> Uri {
 /// Construct a request from a URI.
 ///
 pub fn req_from_uri(uri: Uri) -> Result(Request(String), Nil) {
-  try scheme = uri.scheme
+  try scheme =
+    uri.scheme
     |> option.unwrap("")
     |> scheme_from_string
-  try host = uri.host
+  try host =
+    uri.host
     |> option.to_result(Nil)
-  let req = Request(
-    method: Get,
-    headers: [],
-    body: "",
-    scheme: scheme,
-    host: host,
-    port: uri.port,
-    path: uri.path,
-    query: uri.query,
-  )
+  let req =
+    Request(
+      method: Get,
+      headers: [],
+      body: "",
+      scheme: scheme,
+      host: host,
+      port: uri.port,
+      path: uri.path,
+      query: uri.query,
+    )
   Ok(req)
 }
 
@@ -205,7 +208,6 @@ pub fn get_query(
 }
 
 // TODO: escape
-// TODO: record update syntax
 /// Set the query of the request.
 ///
 pub fn set_query(
@@ -215,32 +217,14 @@ pub fn set_query(
   let pair = fn(t: tuple(String, String)) {
     string_builder.from_strings([t.0, "=", t.1])
   }
-  let query = query
+  let query =
+    query
     |> list.map(pair)
     |> list.intersperse(string_builder.from_string("&"))
     |> string_builder.concat
     |> string_builder.to_string
     |> Some
-  let Request(
-    method: method,
-    headers: headers,
-    body: body,
-    scheme: scheme,
-    host: host,
-    port: port,
-    path: path,
-    query: _,
-  ) = req
-  Request(
-    method: method,
-    headers: headers,
-    body: body,
-    scheme: scheme,
-    host: host,
-    port: port,
-    path: path,
-    query: query,
-  )
+  Request(..req, query: query)
 }
 
 /// Get the value for a given header.
@@ -265,7 +249,6 @@ pub fn get_resp_header(
   list.key_find(response.headers, string.lowercase(key))
 }
 
-// TODO: use record update syntax
 // TODO: document
 // https://github.com/elixir-plug/plug/blob/dfebbebeb716c43c7dee4915a061bede06ec45f1/lib/plug/conn.ex#L809
 pub fn prepend_req_header(
@@ -273,12 +256,10 @@ pub fn prepend_req_header(
   key: String,
   value: String,
 ) -> Request(body) {
-  let Request(method, headers, body, scheme, host, port, path, query) = request
-  let headers = [tuple(string.lowercase(key), value), ..headers]
-  Request(method, headers, body, scheme, host, port, path, query)
+  let headers = [tuple(string.lowercase(key), value), ..request.headers]
+  Request(..request, headers: headers)
 }
 
-// TODO: use record update syntax
 // TODO: document
 // https://github.com/elixir-plug/plug/blob/dfebbebeb716c43c7dee4915a061bede06ec45f1/lib/plug/conn.ex#L809
 pub fn prepend_resp_header(
@@ -286,9 +267,8 @@ pub fn prepend_resp_header(
   key: String,
   value: String,
 ) -> Response(body) {
-  let Response(status, headers, body) = response
-  let headers = [tuple(string.lowercase(key), value), ..headers]
-  Response(status, headers, body)
+  let headers = [tuple(string.lowercase(key), value), ..response.headers]
+  Response(..response, headers: headers)
 }
 
 /// Set the body of the response, overwriting any existing body.
@@ -304,10 +284,7 @@ pub fn set_resp_body(
 // TODO: record update syntax
 /// Set the body of the request, overwriting any existing body.
 ///
-pub fn set_req_body(
-  req: Request(old_body),
-  body: new_body,
-) -> Request(new_body) {
+pub fn set_req_body(req: Request(old_body), body: new_body) -> Request(new_body) {
   let Request(
     method: method,
     headers: headers,
@@ -330,30 +307,10 @@ pub fn set_req_body(
   )
 }
 
-// TODO: record update syntax
 /// Set the method of the request.
 ///
 pub fn set_method(req: Request(body), method: Method) -> Request(body) {
-  let Request(
-    method: _,
-    headers: headers,
-    body: body,
-    scheme: scheme,
-    host: host,
-    port: port,
-    path: path,
-    query: query,
-  ) = req
-  Request(
-    method: method,
-    headers: headers,
-    body: body,
-    scheme: scheme,
-    host: host,
-    port: port,
-    path: path,
-    query: query,
-  )
+  Request(..req, method: method)
 }
 
 /// Update the body of a response using a given function.
@@ -417,56 +374,16 @@ pub fn default_req() -> Request(BitString) {
   )
 }
 
-// TODO: record update syntax
 /// Set the method of the request.
 ///
 pub fn set_host(req: Request(body), host: String) -> Request(body) {
-  let Request(
-    method: method,
-    headers: headers,
-    body: body,
-    scheme: scheme,
-    host: _,
-    port: port,
-    path: path,
-    query: query,
-  ) = req
-  Request(
-    method: method,
-    headers: headers,
-    body: body,
-    scheme: scheme,
-    host: host,
-    port: port,
-    path: path,
-    query: query,
-  )
+  Request(..req, host: host)
 }
 
-// TODO: record update syntax
 /// Set the path of the request.
 ///
 pub fn set_path(req: Request(body), path: String) -> Request(body) {
-  let Request(
-    method: method,
-    headers: headers,
-    body: body,
-    scheme: scheme,
-    host: host,
-    port: port,
-    path: _,
-    query: query,
-  ) = req
-  Request(
-    method: method,
-    headers: headers,
-    body: body,
-    scheme: scheme,
-    host: host,
-    port: port,
-    path: path,
-    query: query,
-  )
+  Request(..req, path: path)
 }
 
 fn check_token(token: BitString) {
@@ -485,21 +402,19 @@ fn check_token(token: BitString) {
 fn parse_cookie_list(cookie_string) {
   assert Ok(re) = regex.from_string("[,;]")
   regex.split(re, cookie_string)
-  |> list.filter_map(
-    fn(pair) {
-      case string.split_once(string.trim(pair), "=") {
-        Ok(tuple("", _)) -> Error(Nil)
-        Ok(tuple(key, value)) -> {
-          let key = string.trim(key)
-          let value = string.trim(value)
-          try _ = check_token(bit_string.from_string(key))
-          try _ = check_token(bit_string.from_string(value))
-          Ok(tuple(key, value))
-        }
-        Error(Nil) -> Error(Nil)
+  |> list.filter_map(fn(pair) {
+    case string.split_once(string.trim(pair), "=") {
+      Ok(tuple("", _)) -> Error(Nil)
+      Ok(tuple(key, value)) -> {
+        let key = string.trim(key)
+        let value = string.trim(value)
+        try _ = check_token(bit_string.from_string(key))
+        try _ = check_token(bit_string.from_string(value))
+        Ok(tuple(key, value))
       }
-    },
-  )
+      Error(Nil) -> Error(Nil)
+    }
+  })
 }
 
 /// Fetch the cookies sent in a request.
@@ -510,15 +425,13 @@ pub fn get_req_cookies(req) -> List(tuple(String, String)) {
   let Request(headers: headers, ..) = req
 
   headers
-  |> list.filter_map(
-    fn(header) {
-      let tuple(name, value) = header
-      case name {
-        "cookie" -> Ok(parse_cookie_list(value))
-        _ -> Error(Nil)
-      }
-    },
-  )
+  |> list.filter_map(fn(header) {
+    let tuple(name, value) = header
+    case name {
+      "cookie" -> Ok(parse_cookie_list(value))
+      _ -> Error(Nil)
+    }
+  })
   |> list.flatten()
 }
 
@@ -544,40 +457,19 @@ fn same_site_to_string(policy) {
 /// Send a cookie with a request
 ///
 /// Multiple cookies are added to the same cookie header.
-pub fn set_req_cookie(req, name, value) {
-  let Request(
-    method: method,
-    headers: headers,
-    body: body,
-    scheme: scheme,
-    host: host,
-    port: port,
-    path: path,
-    query: query,
-  ) = req
+pub fn set_req_cookie(req: Request(body), name: String, value: String) {
   let new_cookie_string = string.join([name, value], "=")
 
-  let tuple(cookies_string, headers) = case list.key_pop(headers, "cookie") {
+  let tuple(cookies_string, headers) = case list.key_pop(req.headers, "cookie") {
     Ok(tuple(cookies_string, headers)) -> {
-      let cookies_string = string.join(
-        [cookies_string, new_cookie_string],
-        "; ",
-      )
+      let cookies_string =
+        string.join([cookies_string, new_cookie_string], "; ")
       tuple(cookies_string, headers)
     }
-    Error(Nil) -> tuple(new_cookie_string, headers)
+    Error(Nil) -> tuple(new_cookie_string, req.headers)
   }
 
-  Request(
-    method: method,
-    headers: [tuple("cookie", cookies_string), ..headers],
-    body: body,
-    scheme: scheme,
-    host: host,
-    port: port,
-    path: path,
-    query: query,
-  )
+  Request(..req, headers: [tuple("cookie", cookies_string), ..headers])
 }
 
 /// Attributes of a cookie when sent to a client in the `set-cookie` header.
@@ -650,10 +542,8 @@ fn cookie_attributes_to_list(attributes) {
 ///
 /// The attributes record is defined in `gleam/http/cookie`
 pub fn set_resp_cookie(resp, name, value, attributes) {
-  let header_value = [
-      [name, "=", value],
-      ..cookie_attributes_to_list(attributes)
-    ]
+  let header_value =
+    [[name, "=", value], ..cookie_attributes_to_list(attributes)]
     |> list.map(string.join(_, ""))
     |> string.join("; ")
   prepend_resp_header(resp, "set-cookie", header_value)
@@ -671,13 +561,6 @@ pub fn expire_resp_cookie(resp, name, attributes) {
     http_only: http_only,
     same_site: same_site,
   ) = attributes
-  let attrs = CookieAttributes(
-    max_age: Some(0),
-    domain: domain,
-    path: path,
-    secure: secure,
-    http_only: http_only,
-    same_site: same_site,
-  )
+  let attrs = CookieAttributes(..attributes, max_age: Some(0))
   set_resp_cookie(resp, name, "", attrs)
 }

--- a/test/gleam/http/middleware_test.gleam
+++ b/test/gleam/http/middleware_test.gleam
@@ -3,7 +3,8 @@ import gleam/http.{Delete, Get, Patch, Post, Put, Request, Response}
 import gleam/http/middleware
 
 pub fn method_override_test() {
-  let service = fn(req: Request(a)) {
+  let service =
+    fn(req: Request(a)) {
       http.response(200)
       |> http.set_resp_body(req.method)
     }

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -666,20 +666,7 @@ pub fn req_to_uri_test() {
   http.Https
   |> make_request
   |> http.req_to_uri
-  |> should.equal(
-    Uri(Some("https"), None, Some("sky.net"), None, "/sarah/connor", None, None),
-  )
-
-  http.Http
-  |> make_request
-  |> http.req_to_uri
-  |> should.equal(
-    Uri(Some("http"), None, Some("sky.net"), None, "/sarah/connor", None, None),
-  )
-}
-
-pub fn req_from_uri_test() {
-  let uri = Uri(
+  |> should.equal(Uri(
     Some("https"),
     None,
     Some("sky.net"),
@@ -687,23 +674,37 @@ pub fn req_from_uri_test() {
     "/sarah/connor",
     None,
     None,
-  )
+  ))
+
+  http.Http
+  |> make_request
+  |> http.req_to_uri
+  |> should.equal(Uri(
+    Some("http"),
+    None,
+    Some("sky.net"),
+    None,
+    "/sarah/connor",
+    None,
+    None,
+  ))
+}
+
+pub fn req_from_uri_test() {
+  let uri =
+    Uri(Some("https"), None, Some("sky.net"), None, "/sarah/connor", None, None)
   uri
   |> http.req_from_uri
-  |> should.equal(
-    Ok(
-      http.Request(
-        method: http.Get,
-        headers: [],
-        body: "",
-        scheme: http.Https,
-        host: "sky.net",
-        port: None,
-        path: "/sarah/connor",
-        query: None,
-      ),
-    ),
-  )
+  |> should.equal(Ok(http.Request(
+    method: http.Get,
+    headers: [],
+    body: "",
+    scheme: http.Https,
+    host: "sky.net",
+    port: None,
+    path: "/sarah/connor",
+    query: None,
+  )))
 }
 
 pub fn redirect_test() {
@@ -714,16 +715,17 @@ pub fn redirect_test() {
 }
 
 pub fn path_segments_test() {
-  let request = http.Request(
-    method: http.Get,
-    headers: [],
-    body: Nil,
-    scheme: http.Https,
-    host: "nostromo.ship",
-    port: None,
-    path: "/ellen/ripley",
-    query: None,
-  )
+  let request =
+    http.Request(
+      method: http.Get,
+      headers: [],
+      body: Nil,
+      scheme: http.Https,
+      host: "nostromo.ship",
+      port: None,
+      path: "/ellen/ripley",
+      query: None,
+    )
 
   should.equal(["ellen", "ripley"], http.path_segments(request))
 }
@@ -753,16 +755,17 @@ pub fn get_query_test() {
 }
 
 pub fn set_query_test() {
-  let request = http.Request(
-    method: http.Get,
-    headers: [],
-    body: Nil,
-    scheme: http.Https,
-    host: "example.com",
-    port: None,
-    path: "/",
-    query: None,
-  )
+  let request =
+    http.Request(
+      method: http.Get,
+      headers: [],
+      body: Nil,
+      scheme: http.Https,
+      host: "example.com",
+      port: None,
+      path: "/",
+      query: None,
+    )
 
   let query = [tuple("answer", "42"), tuple("test", "123")]
   let updated_request = http.set_query(request, query)
@@ -812,18 +815,20 @@ pub fn set_req_body_test() {
   "
   ""
 
-  let request = http.Request(
-    method: http.Get,
-    headers: [],
-    body: Nil,
-    scheme: http.Https,
-    host: "example.com",
-    port: None,
-    path: "/",
-    query: None,
-  )
+  let request =
+    http.Request(
+      method: http.Get,
+      headers: [],
+      body: Nil,
+      scheme: http.Https,
+      host: "example.com",
+      port: None,
+      path: "/",
+      query: None,
+    )
 
-  let updated_request = request
+  let updated_request =
+    request
     |> http.set_req_body(body)
 
   updated_request.body
@@ -831,19 +836,21 @@ pub fn set_req_body_test() {
 }
 
 pub fn set_method_test() {
-  let request = http.Request(
-    method: http.Get,
-    headers: [],
-    body: "",
-    scheme: http.Https,
-    host: "example.com",
-    port: None,
-    path: "/",
-    query: None,
-  )
+  let request =
+    http.Request(
+      method: http.Get,
+      headers: [],
+      body: "",
+      scheme: http.Https,
+      host: "example.com",
+      port: None,
+      path: "/",
+      query: None,
+    )
 
   let updated_request_method = http.Post
-  let updated_request = request
+  let updated_request =
+    request
     |> http.set_method(updated_request_method)
 
   updated_request.method
@@ -857,7 +864,8 @@ fn reverse_body(old_body: String) {
 pub fn map_resp_body_test() {
   let response = http.Response(status: 200, headers: [], body: "abcd")
   let expected_updated_body = "dcba"
-  let updated_response = response
+  let updated_response =
+    response
     |> http.map_resp_body(reverse_body)
 
   updated_response.body
@@ -865,11 +873,13 @@ pub fn map_resp_body_test() {
 }
 
 pub fn map_req_body_test() {
-  let request = http.default_req()
+  let request =
+    http.default_req()
     |> http.set_req_body("abcd")
 
   let expected_updated_body = "dcba"
-  let updated_request = request
+  let updated_request =
+    request
     |> http.map_req_body(reverse_body)
 
   updated_request.body
@@ -892,18 +902,16 @@ pub fn try_map_resp_body_test() {
 
 pub fn default_request_test() {
   http.default_req()
-  |> should.equal(
-    http.Request(
-      method: http.Get,
-      headers: [],
-      body: <<>>,
-      scheme: http.Https,
-      host: "localhost",
-      port: None,
-      path: "",
-      query: None,
-    ),
-  )
+  |> should.equal(http.Request(
+    method: http.Get,
+    headers: [],
+    body: <<>>,
+    scheme: http.Https,
+    host: "localhost",
+    port: None,
+    path: "",
+    query: None,
+  ))
 }
 
 pub fn set_host_test() {
@@ -912,7 +920,8 @@ pub fn set_host_test() {
   original_request.host
   |> should.equal("localhost")
 
-  let updated_request = original_request
+  let updated_request =
+    original_request
     |> http.set_host(new_host)
 
   // host should be updated
@@ -926,7 +935,8 @@ pub fn set_path_test() {
   original_request.path
   |> should.equal("")
 
-  let updated_request = original_request
+  let updated_request =
+    original_request
     |> http.set_path(new_path)
 
   // path should be updated
@@ -935,7 +945,8 @@ pub fn set_path_test() {
 }
 
 pub fn get_resp_header_test() {
-  let response = http.response(200)
+  let response =
+    http.response(200)
     |> http.prepend_resp_header("x-foo", "x")
     |> http.prepend_resp_header("x-BAR", "y")
 
@@ -953,7 +964,8 @@ pub fn get_resp_header_test() {
 }
 
 pub fn resp_body_test() {
-  let response = http.response(200)
+  let response =
+    http.response(200)
     |> http.set_resp_body("Hello, World!")
 
   response.body
@@ -986,7 +998,8 @@ pub fn scheme_from_string_test() {
 
 pub fn prepend_req_header_test() {
   let headers = []
-  let request = http.Request(
+  let request =
+    http.Request(
       method: http.Get,
       headers: headers,
       body: Nil,
@@ -1001,7 +1014,8 @@ pub fn prepend_req_header_test() {
   request.headers
   |> should.equal([tuple("answer", "42")])
 
-  let request = request
+  let request =
+    request
     |> http.prepend_req_header("gleam", "awesome")
 
   // request should have two headers now
@@ -1045,7 +1059,8 @@ pub fn get_req_cookies_test() {
 }
 
 pub fn set_req_cookies_test() {
-  let request = http.default_req()
+  let request =
+    http.default_req()
     |> http.set_req_cookie("k1", "v1")
 
   request
@@ -1059,14 +1074,15 @@ pub fn set_req_cookies_test() {
 }
 
 pub fn set_resp_cookie_test() {
-  let empty = http.CookieAttributes(
-    max_age: None,
-    domain: None,
-    path: None,
-    secure: False,
-    http_only: False,
-    same_site: None,
-  )
+  let empty =
+    http.CookieAttributes(
+      max_age: None,
+      domain: None,
+      path: None,
+      secure: False,
+      http_only: False,
+      same_site: None,
+    )
   http.response(200)
   |> http.set_resp_cookie("k1", "v1", empty)
   |> http.get_resp_header("set-cookie")
@@ -1077,29 +1093,28 @@ pub fn set_resp_cookie_test() {
   |> http.get_resp_header("set-cookie")
   |> should.equal(Ok("k1=v1; Path=/; HttpOnly"))
 
-  let secure = http.CookieAttributes(
-    max_age: Some(100),
-    domain: Some("domain.test"),
-    path: Some("/foo"),
-    secure: True,
-    http_only: True,
-    same_site: Some(http.Strict),
-  )
+  let secure =
+    http.CookieAttributes(
+      max_age: Some(100),
+      domain: Some("domain.test"),
+      path: Some("/foo"),
+      secure: True,
+      http_only: True,
+      same_site: Some(http.Strict),
+    )
   http.response(200)
   |> http.set_resp_cookie("k1", "v1", secure)
   |> http.get_resp_header("set-cookie")
-  |> should.equal(
-    Ok(
-      "k1=v1; MaxAge=100; Domain=domain.test; Path=/foo; Secure; HttpOnly; SameSite=Strict",
-    ),
-  )
+  |> should.equal(Ok(
+    "k1=v1; MaxAge=100; Domain=domain.test; Path=/foo; Secure; HttpOnly; SameSite=Strict",
+  ))
 }
 
 pub fn expire_resp_cookie_test() {
   http.response(200)
   |> http.expire_resp_cookie("k1", http.cookie_defaults(Http))
   |> http.get_resp_header("set-cookie")
-  |> should.equal(
-    Ok("k1=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; MaxAge=0; Path=/; HttpOnly"),
-  )
+  |> should.equal(Ok(
+    "k1=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; MaxAge=0; Path=/; HttpOnly",
+  ))
 }


### PR DESCRIPTION
# Overview

This pull request updates the code to use the new record update syntax which went out in the 0.11.0 release.

## Implementation

I updated all of the areas I could find in the code which either had TODO comments to update the record syntax, or where I found it could be done. There was one area, however, which I was unable to make the change despite the TODO comment associated with it. This is the `set_req_body` function. I believe the issue is the changing of the `body` type, but please correct me if I'm wrong.

While I was in here, I also ran the `gleam format` command against the codebase.