### PR TITLE
Make default response body BitString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 - Fix bug to correctly set cookie `Max-Age` attribute
 - The `gleam/http.default_req` function returns a `Request(BitString)` instead
-  `Request(String)`
+  of `Request(String)`
+- The `gleam/http.response` function returns a `Response(BitString)` instead
+  of `Response(Nil)`
 
 ## v1.3.0 - 2020-08-04
 
@@ -17,7 +19,6 @@
 - Created the `gleam/http/cookie` module with `SameSitePolicy` and `Attributes`
   types, along with associated functions `empty_attributes`,
   `default_attributes`, `expire_attributes` and `set_cookie_string`.
-
 
 ## v1.1.1 - 2020-07-21
 

--- a/rebar.config
+++ b/rebar.config
@@ -14,5 +14,5 @@
 {project_plugins, [rebar_gleam, rebar3_hex]}.
 
 {deps, [
-    {gleam_stdlib, "~> 0.10.0"}
+    {gleam_stdlib, "~> 0.11.0"}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,8 @@
-{"1.1.0",
-[{<<"gleam_stdlib">>,{pkg,<<"gleam_stdlib">>,<<"0.10.1">>},0}]}.
+{"1.2.0",
+[{<<"gleam_stdlib">>,{pkg,<<"gleam_stdlib">>,<<"0.11.0">>},0}]}.
 [
 {pkg_hash,[
- {<<"gleam_stdlib">>, <<"F123F33E03B5CDF5E19FC179B9EE81269DEB93F7DEFADB17EF2930E4DB9011E7">>}]}
+ {<<"gleam_stdlib">>, <<"9B1089739574CDF78A1C25A463D770A98F59E63A92324D17095AD67E867EE549">>}]},
+{pkg_hash_ext,[
+ {<<"gleam_stdlib">>, <<"5508E169E20369FC8D400481D3F37CCB2CFD880509F63D6E2B6D85F939BC991B">>}]}
 ].

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -183,11 +183,11 @@ pub fn req_from_uri(uri: Uri) -> Result(Request(String), Nil) {
 
 /// Construct an empty Response.
 ///
-/// The body type of the returned response is `Nil`, and should be set with a
+/// The body type of the returned response is `BitString`, and should be set with a
 /// call to `set_resp_body`.
 ///
-pub fn response(status: Int) -> Response(Nil) {
-  Response(status: status, headers: [], body: Nil)
+pub fn response(status: Int) -> Response(BitString) {
+  Response(status: status, headers: [], body: <<>>)
 }
 
 /// Return the non-empty segments of a request path.

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -350,11 +350,11 @@ pub fn try_map_resp_body(
 
 /// Create a response that redirects to the given uri.
 ///
-pub fn redirect(uri: String) -> Response(String) {
+pub fn redirect(uri: String) -> Response(BitString) {
   Response(
     status: 303,
     headers: [tuple("location", uri)],
-    body: string.append("You are being redirected to ", uri),
+    body: <<string.append("You are being redirected to ", uri):utf8>>,
   )
 }
 

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -20,6 +20,7 @@ import gleam/result
 import gleam/string
 import gleam/string_builder
 import gleam/uri.{Uri}
+import gleam/bit_builder.{BitBuilder}
 
 /// HTTP standard method as defined by [RFC 2616](https://tools.ietf.org/html/rfc2616),
 /// and PATCH which is defined by [RFC 5789](https://tools.ietf.org/html/rfc5789).
@@ -183,11 +184,11 @@ pub fn req_from_uri(uri: Uri) -> Result(Request(String), Nil) {
 
 /// Construct an empty Response.
 ///
-/// The body type of the returned response is `BitString`, and should be set with a
+/// The body type of the returned response is `BitBuilder`, and should be set with a
 /// call to `set_resp_body`.
 ///
-pub fn response(status: Int) -> Response(BitString) {
-  Response(status: status, headers: [], body: <<>>)
+pub fn response(status: Int) -> Response(BitBuilder) {
+  Response(status: status, headers: [], body: bit_builder.from_string(""))
 }
 
 /// Return the non-empty segments of a request path.
@@ -350,11 +351,12 @@ pub fn try_map_resp_body(
 
 /// Create a response that redirects to the given uri.
 ///
-pub fn redirect(uri: String) -> Response(BitString) {
+pub fn redirect(uri: String) -> Response(BitBuilder) {
   Response(
     status: 303,
     headers: [tuple("location", uri)],
-    body: <<string.append("You are being redirected to ", uri):utf8>>,
+    body: string.append("You are being redirected to ", uri)
+    |> bit_builder.from_string,
   )
 }
 


### PR DESCRIPTION
# Overview

This is related to #17.

The default `response` function now returns a `Response(BitString)` rather than a `Response(Nil)`.

