### PR TITLE
fix max age bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.3.1 - TBC
 
+- Fix bug to correctly set cookie `Max-Age` attribute
 - The `gleam/http.default_req` function returns a `Request(BitString)` instead
   `Request(String)`
 

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -519,7 +519,7 @@ fn cookie_attributes_to_list(attributes) {
       Some(0) -> Some([epoch])
       _ -> option.None
     },
-    option.map(max_age, fn(max_age) { ["MaxAge=", int.to_string(max_age)] }),
+    option.map(max_age, fn(max_age) { ["Max-Age=", int.to_string(max_age)] }),
     option.map(domain, fn(domain) { ["Domain=", domain] }),
     option.map(path, fn(path) { ["Path=", path] }),
     case secure {

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -1099,7 +1099,7 @@ pub fn set_resp_cookie_test() {
   |> http.set_resp_cookie("k1", "v1", secure)
   |> http.get_resp_header("set-cookie")
   |> should.equal(Ok(
-    "k1=v1; MaxAge=100; Domain=domain.test; Path=/foo; Secure; HttpOnly; SameSite=Strict",
+    "k1=v1; Max-Age=100; Domain=domain.test; Path=/foo; Secure; HttpOnly; SameSite=Strict",
   ))
 }
 
@@ -1108,6 +1108,6 @@ pub fn expire_resp_cookie_test() {
   |> http.expire_resp_cookie("k1", http.cookie_defaults(Http))
   |> http.get_resp_header("set-cookie")
   |> should.equal(Ok(
-    "k1=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; MaxAge=0; Path=/; HttpOnly",
+    "k1=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/; HttpOnly",
   ))
 }


### PR DESCRIPTION
The max-age attribute has a hyphen. The others don't and are therefore implemented correctly

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie 