### PR TITLE
update gleam_std lib to 0.11.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,5 +14,5 @@
 {project_plugins, [rebar_gleam, rebar3_hex]}.
 
 {deps, [
-    {gleam_stdlib, "~> 0.10.0"}
+    {gleam_stdlib, "~> 0.11.0"}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,8 @@
-{"1.1.0",
-[{<<"gleam_stdlib">>,{pkg,<<"gleam_stdlib">>,<<"0.10.1">>},0}]}.
+{"1.2.0",
+[{<<"gleam_stdlib">>,{pkg,<<"gleam_stdlib">>,<<"0.11.0">>},0}]}.
 [
 {pkg_hash,[
- {<<"gleam_stdlib">>, <<"F123F33E03B5CDF5E19FC179B9EE81269DEB93F7DEFADB17EF2930E4DB9011E7">>}]}
+ {<<"gleam_stdlib">>, <<"9B1089739574CDF78A1C25A463D770A98F59E63A92324D17095AD67E867EE549">>}]},
+{pkg_hash_ext,[
+ {<<"gleam_stdlib">>, <<"5508E169E20369FC8D400481D3F37CCB2CFD880509F63D6E2B6D85F939BC991B">>}]}
 ].


### PR DESCRIPTION
Hello! This PR updates gleam/http to the latest version of gleam_stblib(to go with [this PR](https://github.com/gleam-lang/httpc/pull/7)). If there was a plan to hold off on updating gealm_stdlib, feel free to decline this PR.