### PR TITLE
Add get_req_origin function to get origin header from request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.3.1 - TBC
 
+- The `gleam/http` module gains the `get_req_origin` function.
 - Fix bug to correctly set cookie `Max-Age` attribute
 - The `gleam/http.default_req` function returns a `Request(BitString)` instead
   `Request(String)`
@@ -17,7 +18,6 @@
 - Created the `gleam/http/cookie` module with `SameSitePolicy` and `Attributes`
   types, along with associated functions `empty_attributes`,
   `default_attributes`, `expire_attributes` and `set_cookie_string`.
-
 
 ## v1.1.1 - 2020-07-21
 

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -559,7 +559,7 @@ pub fn expire_resp_cookie(resp, name, attributes) {
 
 /// Get the origin request header
 ///
-/// If no "Origin" header is found in the request, falls back to the "Referer"
+/// If no "origin" header is found in the request, falls back to the "referer"
 /// header.
 pub fn get_req_origin(req: Request(body)) -> Option(String) {
   case get_req_header(req, "origin") {
@@ -569,12 +569,9 @@ pub fn get_req_origin(req: Request(body)) -> Option(String) {
         Ok(ref) ->
           case ref
           |> uri.parse {
-            Ok(uri) ->
-              Some(
-                option.unwrap(uri.scheme, "")
-                |> string.append("://")
-                |> string.append(option.unwrap(uri.host, "")),
-              )
+            Ok(ref_uri) ->
+              uri.origin(ref_uri)
+              |> option.from_result
             Error(Nil) -> option.None
           }
         Error(Nil) -> option.None

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -556,3 +556,14 @@ pub fn expire_resp_cookie(resp, name, attributes) {
   let attrs = CookieAttributes(..attributes, max_age: Some(0))
   set_resp_cookie(resp, name, "", attrs)
 }
+
+/// Get the origin request header
+///
+/// If no "Origin" header is found in the request, falls back to the "Referer"
+/// header.
+pub fn get_req_origin(req: Request(body)) -> Result(String, Nil) {
+  case get_req_header(req, "Origin") {
+    Ok(origin) -> Ok(origin)
+    Error(Nil) -> get_req_header(req, "Referer")
+  }
+}

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -561,9 +561,23 @@ pub fn expire_resp_cookie(resp, name, attributes) {
 ///
 /// If no "Origin" header is found in the request, falls back to the "Referer"
 /// header.
-pub fn get_req_origin(req: Request(body)) -> Result(String, Nil) {
-  case get_req_header(req, "Origin") {
-    Ok(origin) -> Ok(origin)
-    Error(Nil) -> get_req_header(req, "Referer")
+pub fn get_req_origin(req: Request(body)) -> Option(String) {
+  case get_req_header(req, "origin") {
+    Ok(origin) -> Some(origin)
+    Error(Nil) ->
+      case get_req_header(req, "referer") {
+        Ok(ref) ->
+          case ref
+          |> uri.parse {
+            Ok(uri) ->
+              Some(
+                option.unwrap(uri.scheme, "")
+                |> string.append("://")
+                |> string.append(option.unwrap(uri.host, "")),
+              )
+            Error(Nil) -> option.None
+          }
+        Error(Nil) -> option.None
+      }
   }
 }

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -1114,23 +1114,23 @@ pub fn expire_resp_cookie_test() {
 
 pub fn get_req_origin_test() {
   let origin = "http://example.com"
-  let referer = "http://test.com"
+  let referer = "http://test.com/elixir"
 
-  // with 'Origin' header
+  // with 'origin' header
   http.default_req()
-  |> http.prepend_req_header("Origin", origin)
-  |> http.prepend_req_header("Referer", referer)
+  |> http.prepend_req_header("origin", origin)
+  |> http.prepend_req_header("referer", referer)
   |> http.get_req_origin
-  |> should.equal(Ok(origin))
+  |> should.equal(Some("http://example.com"))
 
-  // without 'Origin' header
+  // without 'origin' header
   http.default_req()
-  |> http.prepend_req_header("Referer", referer)
+  |> http.prepend_req_header("referer", referer)
   |> http.get_req_origin
-  |> should.equal(Ok(referer))
+  |> should.equal(Some("http://test.com"))
 
-  // with neither 'Origin' nor 'Referer' headers
+  // with neither 'origin' nor 'referer' headers
   http.default_req()
   |> http.get_req_origin
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 }

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -1111,3 +1111,26 @@ pub fn expire_resp_cookie_test() {
     "k1=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/; HttpOnly",
   ))
 }
+
+pub fn get_req_origin_test() {
+  let origin = "http://example.com"
+  let referer = "http://test.com"
+
+  // with 'Origin' header
+  http.default_req()
+  |> http.prepend_req_header("Origin", origin)
+  |> http.prepend_req_header("Referer", referer)
+  |> http.get_req_origin
+  |> should.equal(Ok(origin))
+
+  // without 'Origin' header
+  http.default_req()
+  |> http.prepend_req_header("Referer", referer)
+  |> http.get_req_origin
+  |> should.equal(Ok(referer))
+
+  // with neither 'Origin' nor 'Referer' headers
+  http.default_req()
+  |> http.get_req_origin
+  |> should.equal(Error(Nil))
+}

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -1114,7 +1114,7 @@ pub fn expire_resp_cookie_test() {
 
 pub fn get_req_origin_test() {
   let origin = "http://example.com"
-  let referer = "http://test.com/elixir"
+  let referer = "http://example.com/elixir"
 
   // with 'origin' header
   http.default_req()
@@ -1127,10 +1127,22 @@ pub fn get_req_origin_test() {
   http.default_req()
   |> http.prepend_req_header("referer", referer)
   |> http.get_req_origin
-  |> should.equal(Some("http://test.com"))
+  |> should.equal(Some("http://example.com"))
 
   // with neither 'origin' nor 'referer' headers
   http.default_req()
+  |> http.get_req_origin
+  |> should.equal(None)
+
+  // with bad 'referer' header - no scheme
+  http.default_req()
+  |> http.prepend_req_header("referer", "example.com")
+  |> http.get_req_origin
+  |> should.equal(None)
+
+  // with bad 'referer' header - no host
+  http.default_req()
+  |> http.prepend_req_header("referer", "ftp://")
   |> http.get_req_origin
   |> should.equal(None)
 }


### PR DESCRIPTION
This is in relation to #22 

@CrowdHailer, let me know if this is similar to the function you create to get this done, or if there's some things which should be updated.