### PR TITLE
Make default request body of type String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## v1.3.1 - TBC
+## v1.5.1 - TBC
+
+- The `gleam/http.default_req` function returns a `Request(String)` again, 
+  reverting the change from v1.5.0
+
+## v1.5.0 - 2020-09-23
 
 - The `gleam/http` module gains the `get_req_origin` function.
 - Fix bug to correctly set cookie `Max-Age` attribute

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -361,11 +361,11 @@ pub fn redirect(uri: String) -> Response(String) {
 /// A request with commonly used default values. This request can be used as
 /// an initial value and then update to create the desired request.
 ///
-pub fn default_req() -> Request(BitString) {
+pub fn default_req() -> Request(String) {
   Request(
     method: Get,
     headers: [],
-    body: <<>>,
+    body: "",
     scheme: Https,
     host: "localhost",
     port: None,

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -898,7 +898,7 @@ pub fn default_request_test() {
   |> should.equal(http.Request(
     method: http.Get,
     headers: [],
-    body: <<>>,
+    body: "",
     scheme: http.Https,
     host: "localhost",
     port: None,


### PR DESCRIPTION
Makes the default request body to a String, from a BitString. For more information regarding this, see #19 