### PR TITLE
Add get_resp_cookie function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - The `gleam/http.default_req` function returns a `Request(String)` again, 
   reverting the change from v1.5.0
+- The `gleam/http` module gains the `get_resp_cookie` function.
 
 ## v1.5.0 - 2020-09-23
 

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -538,6 +538,23 @@ fn cookie_attributes_to_list(attributes) {
   |> list.filter_map(option.to_result(_, Nil))
 }
 
+/// Fetch the cookies sent in a response
+///
+/// Follows the same logic as fetching the cookie from the request
+/// (i.e. badly formed cookies will be ignored)
+pub fn get_resp_cookie(resp) -> List(tuple(String, String)) {
+  let Response(headers: headers, ..) = resp
+  headers
+  |> list.filter_map(fn(header) {
+    let tuple(name, value) = header
+    case name {
+      "set-cookie" -> Ok(parse_cookie_list(value))
+      _ -> Error(Nil)
+    }
+  })
+  |> list.flatten()
+}
+
 /// Set a cookie value for a client
 ///
 /// The attributes record is defined in `gleam/http/cookie`

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -1066,6 +1066,49 @@ pub fn set_req_cookies_test() {
   |> should.equal(Ok("k1=v1; k2=v2"))
 }
 
+pub fn get_resp_cookie_test() {
+  let empty =
+    http.CookieAttributes(
+      max_age: None,
+      domain: None,
+      path: None,
+      secure: False,
+      http_only: False,
+      same_site: None,
+    )
+
+  http.response(200)
+  |> http.set_resp_cookie("k1", "v1", empty)
+  |> http.get_resp_cookie
+  |> should.equal([tuple("k1", "v1")])
+
+  let secure_with_attributes =
+    http.CookieAttributes(
+      max_age: Some(100),
+      domain: Some("domain.test"),
+      path: Some("/foo"),
+      secure: True,
+      http_only: True,
+      same_site: None,
+    )
+
+  http.response(200)
+  |> http.set_resp_cookie("k1", "v1", secure_with_attributes)
+  |> http.get_resp_cookie
+  |> should.equal([
+    tuple("k1", "v1"),
+    tuple("Max-Age", "100"),
+    tuple("Domain", "domain.test"),
+    tuple("Path", "/foo"),
+  ])
+
+  // no response cookie
+  http.response(200)
+  |> http.prepend_resp_header("k1", "v1")
+  |> http.get_resp_cookie
+  |> should.equal([])
+}
+
 pub fn set_resp_cookie_test() {
   let empty =
     http.CookieAttributes(


### PR DESCRIPTION
# Overview

This adds the `get_resp_cookie` function.

## Description

I made an attempt at #15, which adds a function to get the cookie from the response. The implementation is pretty much the same as the `get_req_cookie`.