### PR TITLE
update url to plug in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ alphabetically.
 [cowboy-adapter]: https://github.com/gleam-lang/cowboy
 [elli]:https://github.com/elli-lib/elli
 [elli-adapter]: https://github.com/gleam-lang/elli
-[plug]:https://github.com/elli-lib/elli
+[plug]:https://github.com/elixir-plug/plug
 [plug-adapter]: https://github.com/gleam-lang/plug
 
 ## Client adapters


### PR DESCRIPTION
Hey folks 👋 

I noticed the Plug link took me to Elli instead, so I added in the Plug github repo URL!

Thanks!