### PR TITLE
Pluralise get_resp_cookie to be consistent

### DIFF
--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -554,7 +554,7 @@ fn cookie_attributes_to_list(attributes) {
 ///
 /// Follows the same logic as fetching the cookie from the request
 /// (i.e. badly formed cookies will be ignored)
-pub fn get_resp_cookie(resp) -> List(tuple(String, String)) {
+pub fn get_resp_cookies(resp) -> List(tuple(String, String)) {
   let Response(headers: headers, ..) = resp
   headers
   |> list.filter_map(fn(header) {

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -567,6 +567,11 @@ pub fn get_resp_cookies(resp) -> List(tuple(String, String)) {
   |> list.flatten()
 }
 
+/// Deprecated. Use `get_resp_cookies` instead.
+pub fn get_resp_cookie(resp) {
+  get_resp_cookies(resp)
+}
+
 /// Set a cookie value for a client
 ///
 /// The attributes record is defined in `gleam/http/cookie`

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -1096,7 +1096,7 @@ pub fn set_req_cookies_test() {
   |> should.equal(Ok("k1=v1; k2=v2"))
 }
 
-pub fn get_resp_cookie_test() {
+pub fn get_resp_cookies_test() {
   let empty =
     http.CookieAttributes(
       max_age: None,
@@ -1109,7 +1109,7 @@ pub fn get_resp_cookie_test() {
 
   http.response(200)
   |> http.set_resp_cookie("k1", "v1", empty)
-  |> http.get_resp_cookie
+  |> http.get_resp_cookies
   |> should.equal([tuple("k1", "v1")])
 
   let secure_with_attributes =
@@ -1124,7 +1124,7 @@ pub fn get_resp_cookie_test() {
 
   http.response(200)
   |> http.set_resp_cookie("k1", "v1", secure_with_attributes)
-  |> http.get_resp_cookie
+  |> http.get_resp_cookies
   |> should.equal([
     tuple("k1", "v1"),
     tuple("Max-Age", "100"),
@@ -1135,7 +1135,7 @@ pub fn get_resp_cookie_test() {
   // no response cookie
   http.response(200)
   |> http.prepend_resp_header("k1", "v1")
-  |> http.get_resp_cookie
+  |> http.get_resp_cookies
   |> should.equal([])
 }
 


### PR DESCRIPTION
`get_req_cookies` is plural and returns a `List(tuple(String, String))`

`get_resp_cookie` is **not** plural but also returns `List(tuple(String, String))`