### PR TITLE
Update `get_req_origin` to return a Result, rather than an Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+- The `gleam/http.get_req_origin` function returns a `Result(String, Nil)`
+  instead of an `Option(String)`.
+
 ## v1.7.0 - 2020-11-29
 
 - The `gleam/http` module gains the `get_resp_cookies` function.

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -595,20 +595,18 @@ pub fn expire_resp_cookie(resp, name, attributes) {
 ///
 /// If no "origin" header is found in the request, falls back to the "referer"
 /// header.
-pub fn get_req_origin(req: Request(body)) -> Option(String) {
+pub fn get_req_origin(req: Request(body)) -> Result(String, Nil) {
   case get_req_header(req, "origin") {
-    Ok(origin) -> Some(origin)
+    Ok(origin) -> Ok(origin)
     Error(Nil) ->
       case get_req_header(req, "referer") {
         Ok(ref) ->
           case ref
           |> uri.parse {
-            Ok(ref_uri) ->
-              uri.origin(ref_uri)
-              |> option.from_result
-            Error(Nil) -> option.None
+            Ok(ref_uri) -> uri.origin(ref_uri)
+            Error(Nil) -> Error(Nil)
           }
-        Error(Nil) -> option.None
+        Error(Nil) -> Error(Nil)
       }
   }
 }

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -1194,28 +1194,28 @@ pub fn get_req_origin_test() {
   |> http.prepend_req_header("origin", origin)
   |> http.prepend_req_header("referer", referer)
   |> http.get_req_origin
-  |> should.equal(Some("http://example.com"))
+  |> should.equal(Ok("http://example.com"))
 
   // without 'origin' header
   http.default_req()
   |> http.prepend_req_header("referer", referer)
   |> http.get_req_origin
-  |> should.equal(Some("http://example.com"))
+  |> should.equal(Ok("http://example.com"))
 
   // with neither 'origin' nor 'referer' headers
   http.default_req()
   |> http.get_req_origin
-  |> should.equal(None)
+  |> should.equal(Error(Nil))
 
   // with bad 'referer' header - no scheme
   http.default_req()
   |> http.prepend_req_header("referer", "example.com")
   |> http.get_req_origin
-  |> should.equal(None)
+  |> should.equal(Error(Nil))
 
   // with bad 'referer' header - no host
   http.default_req()
   |> http.prepend_req_header("referer", "ftp://")
   |> http.get_req_origin
-  |> should.equal(None)
+  |> should.equal(Error(Nil))
 }


### PR DESCRIPTION
This is in reference to #31.

The `get_req_origin` function will now return a `Result(String, Nil)` rather than an `Option(String)`.