### PR TITLE
Fix repository name in package metadata

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -3,7 +3,7 @@ version = "2.1.0"
 licences = ["Apache-2.0"]
 description = "Types and functions for Gleam HTTP clients and servers"
 
-repository = { type = "github", user = "gleam-lang", repo = "otp" }
+repository = { type = "github", user = "gleam-lang", repo = "http" }
 links = [
   { title = "Website", href = "https://gleam.run" },
   { title = "Sponsor", href = "https://github.com/sponsors/lpil" },


### PR DESCRIPTION
**Problem**

When trying to click through from the documentation to the implementation, I was taken to a 404 page since the package metadata specifies the repository for this package as 'gleam-lang/otp'. 

**Solution**

Update the repository name from 'otp' to 'http' :grin: 