### PR TITLE
45 request new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Added function `request.to` which takes a url string and attempts to create a request by
+  parsing it as a `Uri`. Returns a result.
+
 ## v3.1.2 - 2023-03-02
 
 - Updated for Gleam v0.27.0.

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -1,6 +1,6 @@
 import gleam/result
 // TODO: validate_req
-import gleam/http.{Header, Method, Scheme}
+import gleam/http.{Get, Header, Method, Scheme}
 import gleam/http/cookie
 import gleam/option.{None, Option, Some}
 import gleam/uri.{Uri}
@@ -50,7 +50,7 @@ pub fn from_uri(uri: Uri) -> Result(Request(String), Nil) {
   )
   let req =
     Request(
-      method: http.Get,
+      method: Get,
       headers: [],
       body: "",
       scheme: scheme,
@@ -178,7 +178,7 @@ pub fn set_method(req: Request(body), method: Method) -> Request(body) {
 ///
 pub fn new() -> Request(String) {
   Request(
-    method: http.Get,
+    method: Get,
     headers: [],
     body: "",
     scheme: http.Https,

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -174,10 +174,17 @@ pub fn set_method(req: Request(body), method: Method) -> Request(body) {
 }
 
 /// Create a request from a provided URI string. 
-pub fn new(url: String) -> Request(String) {
-  let assert Ok(parsed_uri) = uri.parse(url)
-  let assert Ok(req) = from_uri(parsed_uri)
-  req
+pub fn new() -> Request(String) {
+  Request(
+    method: http.Get,
+    headers: [],
+    body: "",
+    scheme: http.Https,
+    host: "localhost",
+    port: option.None,
+    path: "",
+    query: option.None,
+  )
 }
 
 // Helper method for constructing a Request from a url String.
@@ -186,7 +193,7 @@ fn from_url(url: String) -> Result(Request(String), Nil) {
   |> result.flatten
 }
 
-pub fn route(method: Method, url: String) -> Result(Request(String), Nil) {
+pub fn for(method: Method, url: String) -> Result(Request(String), Nil) {
   from_url(url)
   |> result.map(fn(req) {
     req

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -1,6 +1,6 @@
 import gleam/result
 // TODO: validate_req
-import gleam/http.{Get, Post, Header, Method, Scheme}
+import gleam/http.{Get, Header, Method, Scheme}
 import gleam/http/cookie
 import gleam/option.{None, Option, Some}
 import gleam/uri.{Uri}
@@ -191,24 +191,15 @@ pub fn new() -> Request(String) {
 
 // Helper method for constructing a Request from a url String.
 fn from_url(url: String) -> Result(Request(String), Nil) {
-    result.map(uri.parse(url), fn(parsed_uri) {
-      from_uri(parsed_uri)
-    }) |> result.flatten
+  result.map(uri.parse(url), fn(parsed_uri) { from_uri(parsed_uri) })
+  |> result.flatten
 }
 
-/// Construct a default get request from a provided url.
-///
-pub fn get(url: String) -> Result(Request(String), Nil) {
-  from_url(url) |> result.map(fn(req) {
-    req |> set_method(Get)
-  })
-}
-
-/// Construct a default post request from a provided url and body.
-///
-pub fn post(url: String, body: body) -> Result(Request(body), Nil) {
-  from_url(url) |> result.map(fn(req) {
-    req |> set_method(Post) |> set_body(body)
+pub fn route(method: Method, url: String) -> Result(Request(String), Nil) {
+  from_url(url)
+  |> result.map(fn(req) {
+    req
+    |> set_method(method)
   })
 }
 

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -192,8 +192,9 @@ pub fn new() -> Request(String) {
 /// Construct a request from a URL string
 ///
 pub fn to(url: String) -> Result(Request(String), Nil) {
-  result.map(uri.parse(url), fn(parsed_uri) { from_uri(parsed_uri) })
-  |> result.flatten
+  url
+  |> uri.parse
+  |> result.then(from_uri)
 }
 
 /// Set the scheme (protocol) of the request.

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -173,7 +173,9 @@ pub fn set_method(req: Request(body), method: Method) -> Request(body) {
   Request(..req, method: method)
 }
 
-/// Create a request from a provided URI string. 
+/// A request with commonly used default values. This request can be used as
+/// an initial value and then update to create the desired request.
+///
 pub fn new() -> Request(String) {
   Request(
     method: http.Get,
@@ -188,6 +190,7 @@ pub fn new() -> Request(String) {
 }
 
 /// Construct a request from a URL string
+///
 pub fn to(url: String) -> Result(Request(String), Nil) {
   result.map(uri.parse(url), fn(parsed_uri) { from_uri(parsed_uri) })
   |> result.flatten

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -1,6 +1,6 @@
 import gleam/result
 // TODO: validate_req
-import gleam/http.{Get, Header, Method, Scheme}
+import gleam/http.{Get, Post, Header, Method, Scheme}
 import gleam/http/cookie
 import gleam/option.{None, Option, Some}
 import gleam/uri.{Uri}
@@ -187,6 +187,29 @@ pub fn new() -> Request(String) {
     path: "",
     query: option.None,
   )
+}
+
+// Helper method for constructing a Request from a url String.
+fn from_url(url: String) -> Result(Request(String), Nil) {
+    result.map(uri.parse(url), fn(parsed_uri) {
+      from_uri(parsed_uri)
+    }) |> result.flatten
+}
+
+/// Construct a default get request from a provided url.
+///
+pub fn get(url: String) -> Result(Request(String), Nil) {
+  from_url(url) |> result.map(fn(req) {
+    req |> set_method(Get)
+  })
+}
+
+/// Construct a default post request from a provided url and body.
+///
+pub fn post(url: String, body: body) -> Result(Request(body), Nil) {
+  from_url(url) |> result.map(fn(req) {
+    req |> set_method(Post) |> set_body(body)
+  })
 }
 
 /// Set the scheme (protocol) of the request.

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -187,18 +187,10 @@ pub fn new() -> Request(String) {
   )
 }
 
-// Helper method for constructing a Request from a url String.
-fn from_url(url: String) -> Result(Request(String), Nil) {
+/// Construct a request from a URL string
+pub fn to(url: String) -> Result(Request(String), Nil) {
   result.map(uri.parse(url), fn(parsed_uri) { from_uri(parsed_uri) })
   |> result.flatten
-}
-
-pub fn for(method: Method, url: String) -> Result(Request(String), Nil) {
-  from_url(url)
-  |> result.map(fn(req) {
-    req
-    |> set_method(method)
-  })
 }
 
 /// Set the scheme (protocol) of the request.

--- a/test/gleam/http/request_test.gleam
+++ b/test/gleam/http/request_test.gleam
@@ -4,7 +4,6 @@ import gleam/string
 import gleam/http.{Https}
 import gleam/http/request.{Request}
 import gleeunit/should
-import gleam/result
 
 pub fn req_to_uri_test() {
   let make_request = fn(scheme) -> Request(Nil) {
@@ -64,31 +63,14 @@ pub fn req_from_uri_test() {
   )))
 }
 
-pub fn get_req_from_string_test() {
+pub fn req_from_url_test() {
   let url = "https://sky.net/sarah/connor?foo=x%20y"
 
-  request.for(http.Get, url)
+  request.to(url)
   |> should.equal(Ok(Request(
     method: http.Get,
     headers: [],
     body: "",
-    scheme: http.Https,
-    host: "sky.net",
-    port: None,
-    path: "/sarah/connor",
-    query: Some("foo=x%20y"),
-  )))
-}
-
-pub fn post_req_from_string_test() {
-  let url = "https://sky.net/sarah/connor?foo=x%20y"
-
-  request.for(http.Post, url)
-  |> result.map(fn(req) { request.set_body(req, "test body") })
-  |> should.equal(Ok(Request(
-    method: http.Post,
-    headers: [],
-    body: "test body",
     scheme: http.Https,
     host: "sky.net",
     port: None,

--- a/test/gleam/http/request_test.gleam
+++ b/test/gleam/http/request_test.gleam
@@ -67,7 +67,7 @@ pub fn req_from_uri_test() {
 pub fn get_req_from_string_test() {
   let url = "https://sky.net/sarah/connor?foo=x%20y"
 
-  request.route(http.Get, url)
+  request.for(http.Get, url)
   |> should.equal(Ok(Request(
     method: http.Get,
     headers: [],
@@ -83,7 +83,7 @@ pub fn get_req_from_string_test() {
 pub fn post_req_from_string_test() {
   let url = "https://sky.net/sarah/connor?foo=x%20y"
 
-  request.route(http.Post, url)
+  request.for(http.Post, url)
   |> result.map(fn(req) { request.set_body(req, "test body") })
   |> should.equal(Ok(Request(
     method: http.Post,
@@ -239,7 +239,7 @@ pub fn set_method_test() {
 
 pub fn map_req_body_test() {
   let request =
-    request.new("http://localhost")
+    request.new()
     |> request.set_body("abcd")
 
   let expected_updated_body = "dcba"
@@ -250,7 +250,7 @@ pub fn map_req_body_test() {
 }
 
 pub fn set_scheme_test() {
-  let original_request = request.new("https://localhost")
+  let original_request = request.new()
 
   original_request.scheme
   |> should.equal(Https)
@@ -266,7 +266,7 @@ pub fn set_scheme_test() {
 
 pub fn set_host_test() {
   let new_host = "github"
-  let original_request = request.new("http://localhost")
+  let original_request = request.new()
   original_request.host
   |> should.equal("localhost")
 
@@ -280,7 +280,7 @@ pub fn set_host_test() {
 }
 
 pub fn set_port_test() {
-  let original_request = request.new("http://localhost")
+  let original_request = request.new()
 
   original_request.port
   |> should.equal(None)
@@ -296,7 +296,7 @@ pub fn set_port_test() {
 
 pub fn set_path_test() {
   let new_path = "/gleam-lang"
-  let original_request = request.new("http://localhost")
+  let original_request = request.new()
   original_request.path
   |> should.equal("")
 
@@ -411,35 +411,35 @@ pub fn prepend_req_header_test() {
 }
 
 pub fn get_req_cookies_test() {
-  request.new("http://localhost")
+  request.new()
   |> request.prepend_header("cookie", "k1=v1; k2=v2")
   |> request.get_cookies()
   |> should.equal([#("k1", "v1"), #("k2", "v2")])
 
   // Standard Header list syntax
-  request.new("http://localhost")
+  request.new()
   |> request.prepend_header("cookie", "k1=v1, k2=v2")
   |> request.get_cookies()
   |> should.equal([#("k1", "v1"), #("k2", "v2")])
 
   // Spread over multiple headers
-  request.new("http://localhost")
+  request.new()
   |> request.prepend_header("cookie", "k2=v2")
   |> request.prepend_header("cookie", "k1=v1")
   |> request.get_cookies()
   |> should.equal([#("k1", "v1"), #("k2", "v2")])
 
-  request.new("http://localhost")
+  request.new()
   |> request.prepend_header("cookie", " k1  =  v1 ; k2=v2 ")
   |> request.get_cookies()
   |> should.equal([#("k1", "v1"), #("k2", "v2")])
 
-  request.new("http://localhost")
+  request.new()
   |> request.prepend_header("cookie", "k1; =; =123")
   |> request.get_cookies()
   |> should.equal([])
 
-  request.new("http://localhost")
+  request.new()
   |> request.prepend_header("cookie", "k\r1=v2; k1=v\r2")
   |> request.get_cookies()
   |> should.equal([])
@@ -447,7 +447,7 @@ pub fn get_req_cookies_test() {
 
 pub fn set_req_cookies_test() {
   let request =
-    request.new("http://localhost")
+    request.new()
     |> request.set_cookie("k1", "v1")
 
   request

--- a/test/gleam/http/request_test.gleam
+++ b/test/gleam/http/request_test.gleam
@@ -4,6 +4,7 @@ import gleam/string
 import gleam/http.{Https}
 import gleam/http/request.{Request}
 import gleeunit/should
+import gleam/result
 
 pub fn req_to_uri_test() {
   let make_request = fn(scheme) -> Request(Nil) {
@@ -66,7 +67,8 @@ pub fn req_from_uri_test() {
 pub fn get_req_from_string_test() {
   let url = "https://sky.net/sarah/connor?foo=x%20y"
 
-  request.get(url) |> should.equal(Ok(Request(
+  request.route(http.Get, url)
+  |> should.equal(Ok(Request(
     method: http.Get,
     headers: [],
     body: "",
@@ -81,7 +83,9 @@ pub fn get_req_from_string_test() {
 pub fn post_req_from_string_test() {
   let url = "https://sky.net/sarah/connor?foo=x%20y"
 
-  request.post(url, "test body") |> should.equal(Ok(Request(
+  request.route(http.Post, url)
+  |> result.map(fn(req) { request.set_body(req, "test body") })
+  |> should.equal(Ok(Request(
     method: http.Post,
     headers: [],
     body: "test body",

--- a/test/gleam/http/request_test.gleam
+++ b/test/gleam/http/request_test.gleam
@@ -63,6 +63,36 @@ pub fn req_from_uri_test() {
   )))
 }
 
+pub fn get_req_from_string_test() {
+  let url = "https://sky.net/sarah/connor?foo=x%20y"
+
+  request.get(url) |> should.equal(Ok(Request(
+    method: http.Get,
+    headers: [],
+    body: "",
+    scheme: http.Https,
+    host: "sky.net",
+    port: None,
+    path: "/sarah/connor",
+    query: Some("foo=x%20y"),
+  )))
+}
+
+pub fn post_req_from_string_test() {
+  let url = "https://sky.net/sarah/connor?foo=x%20y"
+
+  request.post(url, "test body") |> should.equal(Ok(Request(
+    method: http.Post,
+    headers: [],
+    body: "test body",
+    scheme: http.Https,
+    host: "sky.net",
+    port: None,
+    path: "/sarah/connor",
+    query: Some("foo=x%20y"),
+  )))
+}
+
 pub fn path_segments_test() {
   let request =
     Request(

--- a/test/gleam/http/service_test.gleam
+++ b/test/gleam/http/service_test.gleam
@@ -13,43 +13,43 @@ pub fn method_override_test() {
 
   // No overriding without the query param
   let assert Response(200, [], Get) =
-    request.new("http://localhost")
+    request.new()
     |> request.set_method(Get)
     |> service
 
   let assert Response(200, [], Post) =
-    request.new("http://localhost")
+    request.new()
     |> request.set_method(Post)
     |> service
 
   // Can override
   let assert Response(200, [], Delete) =
-    request.new("http://localhost")
+    request.new()
     |> request.set_method(Post)
     |> request.set_query([#("_method", "DELETE")])
     |> service
 
   let assert Response(200, [], Patch) =
-    request.new("http://localhost")
+    request.new()
     |> request.set_method(Post)
     |> request.set_query([#("_method", "PATCH")])
     |> service
 
   let assert Response(200, [], Put) =
-    request.new("http://localhost")
+    request.new()
     |> request.set_method(Post)
     |> request.set_query([#("_method", "PUT")])
     |> service
 
   // Cannot override with other methods
   let assert Response(200, [], Post) =
-    request.new("http://localhost")
+    request.new()
     |> request.set_method(Post)
     |> request.set_query([#("_method", "OPTIONS")])
     |> service
 
   let assert Response(200, [], Post) =
-    request.new("http://localhost")
+    request.new()
     |> request.set_method(Post)
     |> request.set_query([#("_method", "SOMETHING")])
     |> service


### PR DESCRIPTION
1. Changes the `request.new` function to take a url string as a parameter. It parses the string as a uri then uses that to create the request. It uses assert to avoid results.
2. Provides two new functions, `get` and `post` which also take url strings as parameters. These functions return results at the moment but I don't have strong feelings either way.