### PR TITLE
fix return type for `request.to`

### DIFF
--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -191,7 +191,7 @@ pub fn new() -> Request(String) {
 
 /// Construct a request from a URL string
 ///
-pub fn to(url: String) -> Result(Request(String), Nil) {
+pub fn to(url: String) -> Result(Request(body), Nil) {
   url
   |> uri.parse
   |> result.then(from_uri)


### PR DESCRIPTION
I didn't notice this when looking over the PR, but caught this bug immediately when actually trying to use it 😅