### PR TITLE
Update README HTTP Service Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Types and functions for HTTP clients and servers!
 
 ```gleam
 import gleam/http/elli
-import gleam/http/response.{Response}
-import gleam/http/request.{Request}
-import gleam/bit_builder.{BitBuilder}
+import gleam/http/response.{type Response}
+import gleam/http/request.{type Request}
+import gleam/bytes_builder.{type BytesBuilder}
 
 // Define a HTTP service
 //
-pub fn my_service(request: Request(t)) -> Response(BitBuilder) {
-  let body = bit_builder.from_string("Hello, world!")
+pub fn my_service(_request: Request(t)) -> Response(BytesBuilder) {
+  let body = bytes_builder.from_string("Hello, world!")
 
   response.new(200)
   |> response.prepend_header("made-with", "Gleam")


### PR DESCRIPTION
The HTTP Service Example in README is slightly outdated. It's awesome that I can figure out what I have to change just by reading the LSP warnings.

1. Update import type syntax
2. Update `bit_builder` to  `bytes_builder`