### PR TITLE
(feat): url/percent encode query params

### DIFF
--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -156,15 +156,19 @@ pub fn get_query(request: Request(body)) -> Result(List(#(String, String)), Nil)
   }
 }
 
-// TODO: escape
 /// Set the query of the request.
+/// Query params will be percent encoded before being added to the Request.
 ///
 pub fn set_query(
   req: Request(body),
   query: List(#(String, String)),
 ) -> Request(body) {
   let pair = fn(t: #(String, String)) {
-    string_builder.from_strings([t.0, "=", t.1])
+    string_builder.from_strings([
+      uri.percent_encode(t.0),
+      "=",
+      uri.percent_encode(t.1),
+    ])
   }
   let query =
     query

--- a/test/gleam/http/request_test.gleam
+++ b/test/gleam/http/request_test.gleam
@@ -145,6 +145,11 @@ pub fn set_query_test() {
   let updated_request = request.set_query(request, empty_query)
   updated_request.query
   |> should.equal(Some(""))
+
+  let query = [#("foo bar", "x y")]
+  let updated_request = request.set_query(request, query)
+  updated_request.query
+  |> should.equal(Some("foo%20bar=x%20y"))
 }
 
 pub fn get_req_header_test() {


### PR DESCRIPTION
This adds url/percent encoding to the `request.set_query` function. There was previously a `todo` for adding this.

In addition, a test case was added to `set_query_test` to test for this change.