### PR TITLE
(feat): Add request.set_headers and request.prepend_headers

### DIFF
--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -95,7 +95,7 @@ pub fn prepend_header(
   Request(..request, headers: headers)
 }
 
-/// Set a requests headers using a list.
+/// Set a request's headers using a list.
 ///
 /// Similar to `set_header` but for setting more than a single header at once.
 /// Existing headers on the request will be replaced.

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -95,6 +95,34 @@ pub fn prepend_header(
   Request(..request, headers: headers)
 }
 
+/// Set a requests headers using a list.
+///
+/// Similar to `set_header` but for setting more than a single header at once.
+/// Existing headers on the request will be replaced.
+pub fn set_headers(
+  request: Request(body),
+  headers: List(#(String, String)),
+) -> Request(body) {
+  let new_headers =
+    list.fold(headers, [], fn(acc, header) {
+      list.key_set(acc, string.lowercase(header.0), header.1)
+    })
+  Request(..request, headers: new_headers)
+}
+
+/// Prepend the request header with the given key/values.
+///
+/// Similar to `prepend_header` but for prepending multiple key/values at once.
+/// If a header already exists it prepends another header with the same key.
+pub fn prepend_headers(
+  request: Request(body),
+  headers: List(#(String, String)),
+) -> Request(body) {
+  list.fold(headers, request, fn(acc, header) {
+    prepend_header(acc, header.0, header.1)
+  })
+}
+
 // TODO: record update syntax, which can't be done currently as body type changes
 /// Set the body of the request, overwriting any existing body.
 ///

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -156,15 +156,19 @@ pub fn get_query(request: Request(body)) -> Result(List(#(String, String)), Nil)
   }
 }
 
-// TODO: escape
 /// Set the query of the request.
+/// Query params will be percent encoded before being added to the Request.
 ///
 pub fn set_query(
   req: Request(body),
   query: List(#(String, String)),
 ) -> Request(body) {
   let pair = fn(t: #(String, String)) {
-    string_builder.from_strings([t.0, "=", t.1])
+    string_builder.from_strings([
+      uri.percent_encode(t.0),
+      "=",
+      uri.percent_encode(t.1),
+    ])
   }
   let query =
     query

--- a/test/gleam/http/request_test.gleam
+++ b/test/gleam/http/request_test.gleam
@@ -362,8 +362,6 @@ pub fn set_request_header_lowercases_key_test() {
   |> should.equal([#("uppercase_gleam", "awesome")])
 }
 
-// dillon start
-
 pub fn set_req_headers_test() {
   let request =
     Request(

--- a/test/gleam/http/request_test.gleam
+++ b/test/gleam/http/request_test.gleam
@@ -145,6 +145,11 @@ pub fn set_query_test() {
   let updated_request = request.set_query(request, empty_query)
   updated_request.query
   |> should.equal(Some(""))
+
+  let query = [#("foo bar", "x y")]
+  let updated_request = request.set_query(request, query)
+  updated_request.query
+  |> should.equal(Some("foo%20bar=x%20y"))
 }
 
 pub fn get_req_header_test() {

--- a/test/gleam/http/request_test.gleam
+++ b/test/gleam/http/request_test.gleam
@@ -362,6 +362,73 @@ pub fn set_request_header_lowercases_key_test() {
   |> should.equal([#("uppercase_gleam", "awesome")])
 }
 
+// dillon start
+
+pub fn set_req_headers_test() {
+  let request =
+    Request(
+      method: http.Get,
+      headers: [],
+      body: Nil,
+      scheme: http.Https,
+      host: "example.com",
+      port: None,
+      path: "/",
+      query: None,
+    )
+    |> request.set_headers([
+      #("gleam", "awesome"),
+      #("ocaml", "also pretty cool"),
+    ])
+
+  request.headers
+  |> should.equal([#("gleam", "awesome"), #("ocaml", "also pretty cool")])
+
+  // Set updates existing
+  let request =
+    request
+    |> request.set_headers([#("gleam", "the best")])
+
+  request.headers
+  |> should.equal([#("gleam", "the best")])
+}
+
+pub fn set_request_headers_maintains_value_casing_test() {
+  let request =
+    Request(
+      method: http.Get,
+      headers: [],
+      body: Nil,
+      scheme: http.Https,
+      host: "example.com",
+      port: None,
+      path: "/",
+      query: None,
+    )
+    |> request.set_headers([#("gleam", "UPPERCASE_AWESOME")])
+
+  request.headers
+  |> should.equal([#("gleam", "UPPERCASE_AWESOME")])
+}
+
+pub fn set_request_headers_lowercases_key_test() {
+  let request =
+    Request(
+      method: http.Get,
+      headers: [],
+      body: Nil,
+      scheme: http.Https,
+      host: "example.com",
+      port: None,
+      path: "/",
+      query: None,
+    )
+    |> request.set_headers([#("UPPERCASE_GLEAM", "awesome")])
+
+  request.headers
+  |> should.equal([#("uppercase_gleam", "awesome")])
+}
+
 pub fn prepend_req_header_test() {
   let headers = []
   let request =
@@ -391,6 +458,45 @@ pub fn prepend_req_header_test() {
   let request =
     request
     |> request.prepend_header("gleam", "awesome")
+
+  // request repeats the existing header
+  request.headers
+  |> should.equal([
+    #("gleam", "awesome"),
+    #("gleam", "awesome"),
+    #("answer", "42"),
+  ])
+}
+
+pub fn prepend_req_headers_test() {
+  let headers = []
+  let request =
+    Request(
+      method: http.Get,
+      headers: headers,
+      body: Nil,
+      scheme: http.Https,
+      host: "example.com",
+      port: None,
+      path: "/",
+      query: None,
+    )
+    |> request.prepend_headers([#("answer", "42")])
+
+  request.headers
+  |> should.equal([#("answer", "42")])
+
+  let request =
+    request
+    |> request.prepend_headers([#("gleam", "awesome")])
+
+  // request should have two headers now
+  request.headers
+  |> should.equal([#("gleam", "awesome"), #("answer", "42")])
+
+  let request =
+    request
+    |> request.prepend_headers([#("gleam", "awesome")])
 
   // request repeats the existing header
   request.headers


### PR DESCRIPTION
This PR adds pluralized versions for `set_header` and `prepend_header` that will each take a list of `#(String, String)` and apply them to the request in the same fashion as the singular versions. In addition, tests have been added to cover the new functions.