### PR TITLE
(fix): Make `request.get_headers` fully case insensitive

### DIFF
--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -270,8 +270,7 @@ fn parse_headers_after_prelude(
   // compiler support this.
 
   use <- bool.guard(
-    when: dsize
-    < required_size,
+    when: dsize < required_size,
     return: more_please_headers(parse_headers_after_prelude(_, boundary), data),
   )
 

--- a/src/gleam/http/cookie.gleam
+++ b/src/gleam/http/cookie.gleam
@@ -43,8 +43,7 @@ pub fn defaults(scheme: Scheme) {
     max_age: option.None,
     domain: option.None,
     path: option.Some("/"),
-    secure: scheme
-    == http.Https,
+    secure: scheme == http.Https,
     http_only: True,
     same_site: Some(Lax),
   )

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -5,7 +5,6 @@ import gleam/http/cookie
 import gleam/option.{type Option}
 import gleam/uri.{type Uri, Uri}
 import gleam/list
-import gleam/pair
 import gleam/string
 import gleam/string_builder
 
@@ -68,10 +67,12 @@ pub fn from_uri(uri: Uri) -> Result(Request(String), Nil) {
 /// If the request does not have that header then `Error(Nil)` is returned.
 ///
 pub fn get_header(request: Request(body), key: String) -> Result(String, Nil) {
-  list.find(request.headers, fn(header) {
-    string.lowercase(header.0) == string.lowercase(key)
-  })
-  |> result.map(pair.second)
+  use #(_, value) <- result.try(
+    list.find(request.headers, fn(header) {
+      string.lowercase(header.0) == string.lowercase(key)
+    }),
+  )
+  Ok(value)
 }
 
 /// Set the header with the given value under the given header key.

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -67,9 +67,10 @@ pub fn from_uri(uri: Uri) -> Result(Request(String), Nil) {
 /// If the request does not have that header then `Error(Nil)` is returned.
 ///
 pub fn get_header(request: Request(body), key: String) -> Result(String, Nil) {
+  let lowercased_key = string.lowercase(key)
   use #(_, value) <- result.try(
     list.find(request.headers, fn(header) {
-      string.lowercase(header.0) == string.lowercase(key)
+      string.lowercase(header.0) == lowercased_key
     }),
   )
   Ok(value)

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -5,6 +5,7 @@ import gleam/http/cookie
 import gleam/option.{type Option}
 import gleam/uri.{type Uri, Uri}
 import gleam/list
+import gleam/pair
 import gleam/string
 import gleam/string_builder
 
@@ -67,7 +68,10 @@ pub fn from_uri(uri: Uri) -> Result(Request(String), Nil) {
 /// If the request does not have that header then `Error(Nil)` is returned.
 ///
 pub fn get_header(request: Request(body), key: String) -> Result(String, Nil) {
-  list.key_find(request.headers, string.lowercase(key))
+  list.find(request.headers, fn(header) {
+    string.lowercase(header.0) == string.lowercase(key)
+  })
+  |> result.map(pair.second)
 }
 
 /// Set the header with the given value under the given header key.

--- a/test/gleam/http/request_test.gleam
+++ b/test/gleam/http/request_test.gleam
@@ -178,6 +178,32 @@ pub fn get_req_header_test() {
   |> should.equal(Error(Nil))
 }
 
+pub fn get_req_case_insensitive_header_test() {
+  let make_request = fn(headers) {
+    Request(
+      method: http.Get,
+      headers: headers,
+      body: Nil,
+      scheme: http.Https,
+      host: "example.com",
+      port: None,
+      path: "/",
+      query: None,
+    )
+  }
+
+  let header_key = "GLEAM"
+  let request = make_request([#("ANSWER", "42"), #("GLEAM", "awesome")])
+  request
+  |> request.get_header(header_key)
+  |> should.equal(Ok("awesome"))
+
+  let request = make_request([#("answer", "42")])
+  request
+  |> request.get_header(header_key)
+  |> should.equal(Error(Nil))
+}
+
 pub fn set_req_body_test() {
   let body =
     "<html>

--- a/test/gleam/http/request_test.gleam
+++ b/test/gleam/http/request_test.gleam
@@ -192,7 +192,7 @@ pub fn get_req_case_insensitive_header_test() {
     )
   }
 
-  let header_key = "GLEAM"
+  let header_key = "gleam"
   let request = make_request([#("ANSWER", "42"), #("GLEAM", "awesome")])
   request
   |> request.get_header(header_key)

--- a/test/gleam/http/request_test.gleam
+++ b/test/gleam/http/request_test.gleam
@@ -192,16 +192,53 @@ pub fn get_req_case_insensitive_header_test() {
     )
   }
 
+  // Test lowercase key -> uppercase header
   let header_key = "gleam"
-  let request = make_request([#("ANSWER", "42"), #("GLEAM", "awesome")])
+  let request = make_request([#("GLEAM", "awesome")])
+
   request
   |> request.get_header(header_key)
   |> should.equal(Ok("awesome"))
 
-  let request = make_request([#("answer", "42")])
+  // Test uppercase key -> uppercase header
+  let header_key = "GLEAM"
+  let request = make_request([#("GLEAM", "awesome")])
+
   request
   |> request.get_header(header_key)
-  |> should.equal(Error(Nil))
+  |> should.equal(Ok("awesome"))
+
+  // Test uppercase key -> lowercase header
+  let header_key = "GLEAM"
+  let request = make_request([#("gleam", "awesome")])
+
+  request
+  |> request.get_header(header_key)
+  |> should.equal(Ok("awesome"))
+
+  // Test random cased key -> lowercase header
+  let header_key = "GlEaM"
+  let request = make_request([#("gleam", "awesome")])
+
+  request
+  |> request.get_header(header_key)
+  |> should.equal(Ok("awesome"))
+
+  // Test uppercase key -> random cased header
+  let header_key = "GLEAM"
+  let request = make_request([#("gLeAm", "awesome")])
+
+  request
+  |> request.get_header(header_key)
+  |> should.equal(Ok("awesome"))
+
+  // Test random cased key -> random cased header
+  let header_key = "GlEaM"
+  let request = make_request([#("gLeAm", "awesome")])
+
+  request
+  |> request.get_header(header_key)
+  |> should.equal(Ok("awesome"))
 }
 
 pub fn set_req_body_test() {


### PR DESCRIPTION
The current implementation of `request.get_headers` fails in situation where the Header key(s) is/are not lowercase. If you construct a `Request` object and supply the headers to the constructor directly, the header keys are never lowercased. #53 would add additional api's to help prevent this in most cases by guiding users to use the builder pattern instead.

However this PR changes `get_headers` to additionally lowercase each headers key while searching.

In addition, I added test coverage for this that validates it failing in `main` and it passing with this pr/change.

 