### PR TITLE
Editting request documentation

### DIFF
--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -231,7 +231,7 @@ pub fn set_scheme(req: Request(body), scheme: Scheme) -> Request(body) {
   Request(..req, scheme: scheme)
 }
 
-/// Set the method of the request.
+/// Set the host of the request.
 ///
 pub fn set_host(req: Request(body), host: String) -> Request(body) {
   Request(..req, host: host)


### PR DESCRIPTION
When creating a new request and using the method `set_host`, the method definition says it sets the **method** of the request rather than the host.

Ex:
```
let req = request.new()
    |> request.set_method(Get) // Set the method of the request
    |> request.set_host("")    // Set the method of the request
```