### PR TITLE
Adds "remove cookie" function to request module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v.3.7.0 - 2024-09-10
+- The `gleam/http/request` module gains the `remove_cookie` function.
+
 ## v3.6.2 - 2024-03-12
 
 - The `gleam/http/service` module has been deprecated in favour of other

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -1,4 +1,3 @@
-import gleam/bool
 import gleam/http.{type Header, type Method, type Scheme, Get}
 import gleam/http/cookie
 import gleam/list
@@ -289,13 +288,14 @@ pub fn get_cookies(req) -> List(#(String, String)) {
 /// Remove a cookie from a request
 ///
 /// Remove a cookie from the request. If no cookie is found return the request unchanged.
+/// This will not remove the cookie from the client.
 pub fn remove_cookie(req: Request(body), name: String) {
   case list.key_pop(req.headers, "cookie") {
     Ok(#(cookies_string, headers)) -> {
       let new_cookies_string =
         string.split(cookies_string, ";")
         |> list.map(string.trim)
-        |> list.filter(fn(str) { string.starts_with(str, name) |> bool.negate })
+        |> list.filter(fn(str) { !string.starts_with(str, name) })
         |> string.join("; ")
 
       Request(..req, headers: [#("cookie", new_cookies_string), ..headers])

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -1,3 +1,4 @@
+import gleam/bool
 import gleam/http.{type Header, type Method, type Scheme, Get}
 import gleam/http/cookie
 import gleam/list
@@ -283,4 +284,22 @@ pub fn get_cookies(req) -> List(#(String, String)) {
     }
   })
   |> list.flatten()
+}
+
+/// Remove a cookie from a request
+///
+/// Remove a cookie from the request. If no cookie is found return the request unchanged.
+pub fn remove_cookie(req: Request(body), name: String) {
+  case list.key_pop(req.headers, "cookie") {
+    Ok(#(cookies_string, headers)) -> {
+      let new_cookies_string =
+        string.split(cookies_string, ";")
+        |> list.map(string.trim)
+        |> list.filter(fn(str) { string.starts_with(str, name) |> bool.negate })
+        |> string.join("; ")
+
+      Request(..req, headers: [#("cookie", new_cookies_string), ..headers])
+    }
+    Error(_) -> req
+  }
 }

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -1,6 +1,5 @@
 import gleam/http.{type Header, type Method, type Scheme, Get}
 import gleam/http/cookie
-import gleam/io
 import gleam/list
 import gleam/option.{type Option}
 import gleam/result

--- a/test/gleam/http/request_test.gleam
+++ b/test/gleam/http/request_test.gleam
@@ -474,3 +474,16 @@ pub fn remove_cookie_from_request_test() {
   |> should.be_ok
   |> should.equal("FIRST_COOKIE=first; THIRD_COOKIE=third")
 }
+
+pub fn only_remove_matching_cookies_test() {
+  request.new()
+  |> request.set_cookie("FIRST_COOKIE", "first")
+  |> request.set_cookie("SECOND_COOKIE", "second")
+  |> request.set_cookie("THIRD_COOKIE", "third")
+  |> request.remove_cookie("SECOND")
+  |> request.get_header("cookie")
+  |> should.be_ok
+  |> should.equal(
+    "FIRST_COOKIE=first; SECOND_COOKIE=second; THIRD_COOKIE=third",
+  )
+}

--- a/test/gleam/http/request_test.gleam
+++ b/test/gleam/http/request_test.gleam
@@ -450,3 +450,27 @@ pub fn set_req_cookies_test() {
   |> request.get_header("cookie")
   |> should.equal(Ok("k1=v1; k2=v2"))
 }
+
+pub fn remove_cookie_from_request_test() {
+  let req =
+    request.new()
+    |> request.set_cookie("FIRST_COOKIE", "first")
+    |> request.set_cookie("SECOND_COOKIE", "second")
+    |> request.set_cookie("THIRD_COOKIE", "third")
+
+  req
+  |> request.get_header("cookie")
+  |> should.be_ok
+  |> should.equal(
+    "FIRST_COOKIE=first; SECOND_COOKIE=second; THIRD_COOKIE=third",
+  )
+
+  let modified_req =
+    req
+    |> request.remove_cookie("SECOND_COOKIE")
+
+  modified_req
+  |> request.get_header("cookie")
+  |> should.be_ok
+  |> should.equal("FIRST_COOKIE=first; THIRD_COOKIE=third")
+}


### PR DESCRIPTION
This pull request adds a remove_cookie function to the request.
This is useful if you want to for example override a cookie sent from the browser. Since set_cookie appends cookies. Existing cookies in the header would therefore take presidence over the newly set cookies. This might be desirable but the remove_cookie function is a solution in the case that it's not.

