### PR TITLE
New: Two new methods for working with query arguments

### DIFF
--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -1,8 +1,8 @@
+import gleam/bool
 import gleam/http.{type Header, type Method, type Scheme, Get}
 import gleam/http/cookie
 import gleam/list
 import gleam/option.{type Option}
-import gleam/pair
 import gleam/result
 import gleam/string
 import gleam/string_builder
@@ -183,10 +183,8 @@ pub fn get_query_arg(
 ) -> Result(#(String, List(String)), Nil) {
   get_query(req)
   |> result.map(fn(qlist) {
-    list.filter(qlist, fn(d) { pair.first(d) == arg })
-    |> list.fold_right(#(arg, []), fn(e, a) {
-      #(arg, [pair.second(a), ..pair.second(e)])
-    })
+    let matching_args = list.key_filter(qlist, arg)
+    #(arg, matching_args)
   })
 }
 
@@ -196,7 +194,9 @@ pub fn get_query_arg(
 /// query parameters.
 pub fn has_query_arg(req: Request(body), any arg: String) -> Bool {
   get_query(req)
-  |> result.map(fn(qlist) { list.any(qlist, fn(pr) { pair.first(pr) == arg }) })
+  |> result.map(fn(qlist) {
+    list.key_filter(qlist, arg) |> list.is_empty |> bool.negate
+  })
   |> result.unwrap(False)
 }
 

--- a/test/gleam/http/request_test.gleam
+++ b/test/gleam/http/request_test.gleam
@@ -123,6 +123,66 @@ pub fn get_query_test() {
   should.equal(Error(Nil), request.get_query(request))
 }
 
+pub fn get_query_arg_test() {
+  let make_request = fn(query) {
+    Request(
+      method: http.Get,
+      headers: [],
+      body: Nil,
+      scheme: http.Https,
+      host: "example.com",
+      port: None,
+      path: "/",
+      query: query,
+    )
+  }
+
+  let request = make_request(Some("foo=bar"))
+  should.equal(Ok(#("foo", ["bar"])), request.get_query_arg(request, "foo"))
+  should.equal(Ok(#("baz", [])), request.get_query_arg(request, "baz"))
+
+  let request = make_request(Some("foo=bar&foo=bif"))
+  should.equal(
+    Ok(#("foo", ["bar", "bif"])),
+    request.get_query_arg(request, "foo"),
+  )
+
+  // ensure empty parameters are maintained as an empty string
+  let request = make_request(Some("foo=&bar=bif"))
+  should.equal(Ok(#("foo", [""])), request.get_query_arg(request, "foo"))
+
+  // ensure invalid query arguments pass through the Error result.
+  let request = make_request(Some("foo=%!2"))
+  should.equal(Error(Nil), request.get_query_arg(request, "foo"))
+}
+
+pub fn has_query_arg_test() {
+  let make_request = fn(query) {
+    Request(
+      method: http.Get,
+      headers: [],
+      body: Nil,
+      scheme: http.Https,
+      host: "example.com",
+      port: None,
+      path: "/",
+      query: query,
+    )
+  }
+
+  let request = make_request(Some("foo=bar"))
+  should.equal(True, request.has_query_arg(request, "foo"))
+  should.equal(False, request.has_query_arg(request, "baz"))
+
+  // ensure empty parameters return True for their presence
+  let request = make_request(Some("foo=&bar=bif"))
+  should.equal(True, request.has_query_arg(request, "foo"))
+
+  // ensure invalid query parameters return False
+  let request = make_request(Some("foo=%!2"))
+  should.equal(False, request.has_query_arg(request, "foo"))
+}
+
 pub fn set_query_test() {
   let request =
     Request(


### PR DESCRIPTION
This PR adds two new arguments for working with query strings.

 - get_query_arg: Returns the value of a given query argument in the form of (arg, [v1, v2, ...]). Will return an empty list for the values if the argument is not in the query string. This behaviour is to match the behaviour of get_query, where a URL with no query parameters returns the empty list.
 - has_query_arg: Checks for the presence of a query argument in a given query.