### PR TITLE
Fix deprecations warnings from stdlib

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -12,6 +12,7 @@ links = [
 
 [dependencies]
 gleam_stdlib = "~> 0.32"
+gleam_regexp = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/src/gleam/http/cookie.gleam
+++ b/src/gleam/http/cookie.gleam
@@ -2,7 +2,7 @@ import gleam/http.{type Scheme}
 import gleam/int
 import gleam/list
 import gleam/option.{type Option, Some}
-import gleam/regex
+import gleam/regexp
 import gleam/result
 import gleam/string
 
@@ -97,8 +97,8 @@ pub fn set_header(name: String, value: String, attributes: Attributes) -> String
 /// discarded.
 ///
 pub fn parse(cookie_string: String) -> List(#(String, String)) {
-  let assert Ok(re) = regex.from_string("[,;]")
-  regex.split(re, cookie_string)
+  let assert Ok(re) = regexp.from_string("[,;]")
+  regexp.split(re, cookie_string)
   |> list.filter_map(fn(pair) {
     case string.split_once(string.trim(pair), "=") {
       Ok(#("", _)) -> Error(Nil)


### PR DESCRIPTION
This PR replaces usage of the `gleam/regex` module with the `gleam_regexp` package