### PR TITLE
Replace `BytesBuilder` to `BytesTree` from example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Types and functions for HTTP clients and servers!
 import gleam/http/elli
 import gleam/http/response.{type Response}
 import gleam/http/request.{type Request}
-import gleam/bytes_builder.{type BytesBuilder}
+import gleam/bytes_tree.{type BytesTree}
 
 // Define a HTTP service
 //
-pub fn my_service(_request: Request(t)) -> Response(BytesBuilder) {
-  let body = bytes_builder.from_string("Hello, world!")
+pub fn my_service(_request: Request(t)) -> Response(BytesTree) {
+  let body = bytes_tree.from_string("Hello, world!")
 
   response.new(200)
   |> response.prepend_header("made-with", "Gleam")


### PR DESCRIPTION
`BytesBuilder` removed at v0.48.0.
Replace `BytesBuilder` to `BytesTree` from example code.