### PR TITLE
Rewrite tests using the `assert` syntax

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -2,7 +2,7 @@ name = "gleam_http"
 version = "4.1.1"
 licences = ["Apache-2.0"]
 description = "Types and functions for Gleam HTTP clients and servers"
-gleam = ">= 1.4.0"
+gleam = ">= 1.11.0"
 
 repository = { type = "github", user = "gleam-lang", repo = "http" }
 links = [

--- a/test/gleam/http/multipart_test.gleam
+++ b/test/gleam/http/multipart_test.gleam
@@ -3,7 +3,6 @@ import gleam/http.{
   MoreRequiredForBody, MoreRequiredForHeaders, MultipartBody, MultipartHeaders,
 }
 import gleam/list
-import gleeunit/should
 
 pub fn parse_multipart_headers_1_test() {
   let input = <<
@@ -22,10 +21,8 @@ This is the body of the message.\r
   let assert Ok(MultipartHeaders(headers, rest)) =
     http.parse_multipart_headers(input, "frontier")
 
-  headers
-  |> should.equal([#("content-type", "text/plain")])
-  rest
-  |> should.equal(<<"This is the body of the message.\r\n--frontier\r\n":utf8>>)
+  assert headers == [#("content-type", "text/plain")]
+  assert rest == <<"This is the body of the message.\r\n--frontier\r\n":utf8>>
 }
 
 pub fn parse_multipart_headers_2_test() {
@@ -42,16 +39,16 @@ Ym9keSBvZiB0aGUgbWVzc2FnZS48L3A+CiAgPC9ib2R5Pgo8L2h0bWw+Cg==\r
   let assert Ok(MultipartHeaders(headers, rest)) =
     http.parse_multipart_headers(input, "wibblewobble")
 
-  headers
-  |> should.equal([
-    #("content-type", "application/octet-stream"),
-    #("content-transfer-encoding", "base64"),
-  ])
-  rest
-  |> should.equal(<<
-    "PGh0bWw+CiAgPGhlYWQ+CiAgPC9oZWFkPgogIDxib2R5PgogICAgPHA+VGhpcyBpcyB0aGUg\r
+  assert headers
+    == [
+      #("content-type", "application/octet-stream"),
+      #("content-transfer-encoding", "base64"),
+    ]
+  assert rest
+    == <<
+      "PGh0bWw+CiAgPGhlYWQ+CiAgPC9oZWFkPgogIDxib2R5PgogICAgPHA+VGhpcyBpcyB0aGUg\r
 Ym9keSBvZiB0aGUgbWVzc2FnZS48L3A+CiAgPC9ib2R5Pgo8L2h0bWw+Cg==\r\n--wibblewobble--":utf8,
-  >>)
+    >>
 }
 
 /// This test uses the `slices` function to split the input into every possible
@@ -81,14 +78,13 @@ This is the body of the message.\r
       Ok(MultipartHeaders(headers, bit_array.append(remaining, after)))
   }
 
-  headers
-  |> should.equal([#("content-type", "text/plain")])
-  rest
-  |> should.equal(<<
-    "This is the body of the message.\r
+  assert headers == [#("content-type", "text/plain")]
+  assert rest
+    == <<
+      "This is the body of the message.\r
 --frontier\r
 ":utf8,
-  >>)
+    >>
 }
 
 /// This test uses the `slices` function to split the input into every possible
@@ -117,16 +113,15 @@ This is the body of the next part\r
       Ok(MultipartBody(body, done, bit_array.append(remaining, after)))
   }
 
-  body
-  |> should.equal(<<"This is the body of the message.":utf8>>)
-  rest
-  |> should.equal(<<
-    "--frontier\r
+  assert body == <<"This is the body of the message.":utf8>>
+  assert rest
+    == <<
+      "--frontier\r
 Content-Type: text/plain\r
 This is the body of the next part\r
 --frontier\r
 ":utf8,
-  >>)
+    >>
 }
 
 fn slices(
@@ -142,15 +137,15 @@ fn slices(
 }
 
 pub fn slices_test() {
-  slices(<<>>, <<"abcde":utf8>>, [])
-  |> should.equal([
-    #(<<"abcde":utf8>>, <<"":utf8>>),
-    #(<<"abcd":utf8>>, <<"e":utf8>>),
-    #(<<"abc":utf8>>, <<"de":utf8>>),
-    #(<<"ab":utf8>>, <<"cde":utf8>>),
-    #(<<"a":utf8>>, <<"bcde":utf8>>),
-    #(<<>>, <<"abcde":utf8>>),
-  ])
+  assert slices(<<>>, <<"abcde":utf8>>, [])
+    == [
+      #(<<"abcde":utf8>>, <<"":utf8>>),
+      #(<<"abcd":utf8>>, <<"e":utf8>>),
+      #(<<"abc":utf8>>, <<"de":utf8>>),
+      #(<<"ab":utf8>>, <<"cde":utf8>>),
+      #(<<"a":utf8>>, <<"bcde":utf8>>),
+      #(<<>>, <<"abcde":utf8>>),
+    ]
 }
 
 pub fn parse_1_test() {
@@ -171,38 +166,35 @@ Ym9keSBvZiB0aGUgbWVzc2FnZS48L3A+CiAgPC9ib2R5Pgo8L2h0bWw+Cg==\r
 
   let assert Ok(MultipartBody(body, False, input)) =
     http.parse_multipart_body(input, "frontier")
-  body
-  |> should.equal(<<
-    "This is a message with multiple parts in MIME format.":utf8,
-  >>)
+  assert body
+    == <<
+      "This is a message with multiple parts in MIME format.":utf8,
+    >>
 
   let assert Ok(MultipartHeaders(headers, input)) =
     http.parse_multipart_headers(input, "frontier")
-  headers
-  |> should.equal([#("content-type", "text/plain")])
+  assert headers == [#("content-type", "text/plain")]
 
   let assert Ok(MultipartBody(body, False, input)) =
     http.parse_multipart_body(input, "frontier")
-  body
-  |> should.equal(<<"This is the body of the message.":utf8>>)
+  assert body == <<"This is the body of the message.":utf8>>
 
   let assert Ok(MultipartHeaders(headers, input)) =
     http.parse_multipart_headers(input, "frontier")
-  headers
-  |> should.equal([
-    #("content-type", "application/octet-stream"),
-    #("content-transfer-encoding", "base64"),
-  ])
+  assert headers
+    == [
+      #("content-type", "application/octet-stream"),
+      #("content-transfer-encoding", "base64"),
+    ]
 
   let assert Ok(MultipartBody(body, True, rest)) =
     http.parse_multipart_body(input, "frontier")
-  body
-  |> should.equal(<<
-    "PGh0bWw+CiAgPGhlYWQ+CiAgPC9oZWFkPgogIDxib2R5PgogICAgPHA+VGhpcyBpcyB0aGUg\r
+  assert body
+    == <<
+      "PGh0bWw+CiAgPGhlYWQ+CiAgPC9oZWFkPgogIDxib2R5PgogICAgPHA+VGhpcyBpcyB0aGUg\r
 Ym9keSBvZiB0aGUgbWVzc2FnZS48L3A+CiAgPC9ib2R5Pgo8L2h0bWw+Cg==":utf8,
-  >>)
-  rest
-  |> should.equal(<<>>)
+    >>
+  assert rest == <<>>
 }
 
 pub fn parse_2_test() {
@@ -232,61 +224,55 @@ Content-Transfer-Encoding: binary\r
 
   let assert Ok(MultipartHeaders(headers, input)) =
     http.parse_multipart_headers(input, "AaB03x")
-  headers
-  |> should.equal([#("content-disposition", "form-data; name=\"submit-name\"")])
+  assert headers
+    == [#("content-disposition", "form-data; name=\"submit-name\"")]
 
   let assert Ok(MultipartBody(body, False, input)) =
     http.parse_multipart_body(input, "AaB03x")
-  body
-  |> should.equal(<<"Larry":utf8>>)
+  assert body == <<"Larry":utf8>>
 
   let assert Ok(MultipartHeaders(headers, input)) =
     http.parse_multipart_headers(input, "AaB03x")
-  headers
-  |> should.equal([
-    #("content-disposition", "form-data; name=\"files\""),
-    // The boundary is changed here!
-    #("content-type", "multipart/mixed; boundary=BbC04y"),
-  ])
+  assert headers
+    == [
+      #("content-disposition", "form-data; name=\"files\""),
+      // The boundary is changed here!
+      #("content-type", "multipart/mixed; boundary=BbC04y"),
+    ]
 
   let assert Ok(MultipartBody(body, False, input)) =
     http.parse_multipart_body(input, "BbC04y")
-  body
-  |> should.equal(<<"":utf8>>)
+  assert body == <<"":utf8>>
 
   let assert Ok(MultipartHeaders(headers, input)) =
     http.parse_multipart_headers(input, "BbC04y")
-  headers
-  |> should.equal([
-    #("content-disposition", "file; filename=\"file1.txt\""),
-    #("content-type", "text/plain"),
-  ])
+  assert headers
+    == [
+      #("content-disposition", "file; filename=\"file1.txt\""),
+      #("content-type", "text/plain"),
+    ]
 
   let assert Ok(MultipartBody(body, False, input)) =
     http.parse_multipart_body(input, "BbC04y")
-  body
-  |> should.equal(<<"... contents of file1.txt ...":utf8>>)
+  assert body == <<"... contents of file1.txt ...":utf8>>
 
   let assert Ok(MultipartHeaders(headers, input)) =
     http.parse_multipart_headers(input, "BbC04y")
-  headers
-  |> should.equal([
-    #("content-disposition", "file; filename=\"file2.gif\""),
-    #("content-type", "image/gif"),
-    #("content-transfer-encoding", "binary"),
-  ])
+  assert headers
+    == [
+      #("content-disposition", "file; filename=\"file2.gif\""),
+      #("content-type", "image/gif"),
+      #("content-transfer-encoding", "binary"),
+    ]
 
   let assert Ok(MultipartBody(body, True, input)) =
     http.parse_multipart_body(input, "BbC04y")
-  body
-  |> should.equal(<<"...contents of file2.gif...":utf8>>)
+  assert body == <<"...contents of file2.gif...":utf8>>
 
   let assert Ok(MultipartBody(body, True, input)) =
     http.parse_multipart_body(input, "AaB03x")
-  body
-  |> should.equal(<<>>)
-  input
-  |> should.equal(<<>>)
+  assert body == <<>>
+  assert input == <<>>
 }
 
 pub fn parse_3_test() {
@@ -302,23 +288,20 @@ This is the epilogue. Here it includes leading CRLF":utf8,
 
   let assert Ok(MultipartBody(body, False, input)) =
     http.parse_multipart_body(input, "boundary")
-  body
-  |> should.equal(<<"This is the preamble.":utf8>>)
+  assert body == <<"This is the preamble.":utf8>>
 
   let assert Ok(MultipartHeaders(headers, input)) =
     http.parse_multipart_headers(input, "boundary")
-  headers
-  |> should.equal([#("content-type", "text/plain")])
+  assert headers == [#("content-type", "text/plain")]
 
   let assert Ok(MultipartBody(body, True, input)) =
     http.parse_multipart_body(input, "boundary")
-  body
-  |> should.equal(<<"This is the body of the message.":utf8>>)
+  assert body == <<"This is the body of the message.":utf8>>
 
-  input
-  |> should.equal(<<
-    "\r\nThis is the epilogue. Here it includes leading CRLF":utf8,
-  >>)
+  assert input
+    == <<
+      "\r\nThis is the epilogue. Here it includes leading CRLF":utf8,
+    >>
 }
 
 pub fn parse_4_test() {
@@ -334,21 +317,17 @@ This is the body of the message.\r
 
   let assert Ok(MultipartBody(body, False, input)) =
     http.parse_multipart_body(input, "boundary")
-  body
-  |> should.equal(<<"This is the preamble.":utf8>>)
+  assert body == <<"This is the preamble.":utf8>>
 
   let assert Ok(MultipartHeaders(headers, input)) =
     http.parse_multipart_headers(input, "boundary")
-  headers
-  |> should.equal([#("content-type", "text/plain")])
+  assert headers == [#("content-type", "text/plain")]
 
   let assert Ok(MultipartBody(body, True, input)) =
     http.parse_multipart_body(input, "boundary")
-  body
-  |> should.equal(<<"This is the body of the message.":utf8>>)
+  assert body == <<"This is the body of the message.":utf8>>
 
-  input
-  |> should.equal(<<"\r\n":utf8>>)
+  assert input == <<"\r\n":utf8>>
 }
 
 pub fn parse_5_test() {
@@ -374,43 +353,41 @@ This is the epilogue.  It is also to be ignored.":utf8,
 
   let assert Ok(MultipartBody(body, False, input)) =
     http.parse_multipart_body(input, "simple boundary")
-  body
-  |> should.equal(<<
-    "This is the preamble.  It is to be ignored, though it\r
+  assert body
+    == <<
+      "This is the preamble.  It is to be ignored, though it\r
 is a handy place for composition agents to include an\r
 explanatory note to non-MIME conformant readers.\r
 ":utf8,
-  >>)
+    >>
 
   let assert Ok(MultipartHeaders(headers, input)) =
     http.parse_multipart_headers(input, "simple boundary")
-  headers
-  |> should.equal([])
+  assert headers == []
 
   let assert Ok(MultipartBody(body, False, input)) =
     http.parse_multipart_body(input, "simple boundary")
-  body
-  |> should.equal(<<
-    "This is implicitly typed plain US-ASCII text.\r
+  assert body
+    == <<
+      "This is implicitly typed plain US-ASCII text.\r
 It does NOT end with a linebreak.":utf8,
-  >>)
+    >>
 
   let assert Ok(MultipartHeaders(headers, input)) =
     http.parse_multipart_headers(input, "simple boundary")
-  headers
-  |> should.equal([#("content-type", "text/plain; charset=us-ascii")])
+  assert headers == [#("content-type", "text/plain; charset=us-ascii")]
 
   let assert Ok(MultipartBody(body, True, input)) =
     http.parse_multipart_body(input, "simple boundary")
-  body
-  |> should.equal(<<
-    "This is explicitly typed plain US-ASCII text.\r
+  assert body
+    == <<
+      "This is explicitly typed plain US-ASCII text.\r
 It DOES end with a linebreak.\r
 ":utf8,
-  >>)
+    >>
 
-  input
-  |> should.equal(<<
-    "\r\n\r\nThis is the epilogue.  It is also to be ignored.":utf8,
-  >>)
+  assert input
+    == <<
+      "\r\n\r\nThis is the epilogue.  It is also to be ignored.":utf8,
+    >>
 }

--- a/test/gleam/http/request_test.gleam
+++ b/test/gleam/http/request_test.gleam
@@ -3,7 +3,6 @@ import gleam/http/request.{type Request, Request}
 import gleam/option.{None, Some}
 import gleam/string
 import gleam/uri.{Uri}
-import gleeunit/should
 
 pub fn req_to_uri_test() {
   let make_request = fn(scheme) -> Request(Nil) {
@@ -19,40 +18,38 @@ pub fn req_to_uri_test() {
     )
   }
 
-  http.Https
-  |> make_request
-  |> request.to_uri
-  |> should.equal(Uri(
-    Some("https"),
-    None,
-    Some("sky.net"),
-    None,
-    "/sarah/connor",
-    None,
-    None,
-  ))
+  assert http.Https
+    |> make_request
+    |> request.to_uri
+    == Uri(
+      Some("https"),
+      None,
+      Some("sky.net"),
+      None,
+      "/sarah/connor",
+      None,
+      None,
+    )
 
-  http.Http
-  |> make_request
-  |> request.to_uri
-  |> should.equal(Uri(
-    Some("http"),
-    None,
-    Some("sky.net"),
-    None,
-    "/sarah/connor",
-    None,
-    None,
-  ))
+  assert http.Http
+    |> make_request
+    |> request.to_uri
+    == Uri(
+      Some("http"),
+      None,
+      Some("sky.net"),
+      None,
+      "/sarah/connor",
+      None,
+      None,
+    )
 }
 
 pub fn req_from_uri_test() {
   let uri =
     Uri(Some("https"), None, Some("sky.net"), None, "/sarah/connor", None, None)
-  uri
-  |> request.from_uri
-  |> should.equal(
-    Ok(Request(
+  assert request.from_uri(uri)
+    == Ok(Request(
       method: http.Get,
       headers: [],
       body: "",
@@ -61,16 +58,14 @@ pub fn req_from_uri_test() {
       port: None,
       path: "/sarah/connor",
       query: None,
-    )),
-  )
+    ))
 }
 
 pub fn req_from_url_test() {
   let url = "https://sky.net/sarah/connor?foo=x%20y"
 
-  request.to(url)
-  |> should.equal(
-    Ok(Request(
+  assert request.to(url)
+    == Ok(Request(
       method: http.Get,
       headers: [],
       body: "",
@@ -79,8 +74,7 @@ pub fn req_from_url_test() {
       port: None,
       path: "/sarah/connor",
       query: Some("foo=x%20y"),
-    )),
-  )
+    ))
 }
 
 pub fn path_segments_test() {
@@ -96,7 +90,7 @@ pub fn path_segments_test() {
       query: None,
     )
 
-  should.equal(["ellen", "ripley"], request.path_segments(request))
+  assert ["ellen", "ripley"] == request.path_segments(request)
 }
 
 pub fn get_query_test() {
@@ -114,13 +108,13 @@ pub fn get_query_test() {
   }
 
   let request = make_request(Some("foo=x%20y"))
-  should.equal(Ok([#("foo", "x y")]), request.get_query(request))
+  assert Ok([#("foo", "x y")]) == request.get_query(request)
 
   let request = make_request(None)
-  should.equal(Ok([]), request.get_query(request))
+  assert Ok([]) == request.get_query(request)
 
   let request = make_request(Some("foo=%!2"))
-  should.equal(Error(Nil), request.get_query(request))
+  assert Error(Nil) == request.get_query(request)
 }
 
 pub fn set_query_test() {
@@ -138,18 +132,15 @@ pub fn set_query_test() {
 
   let query = [#("answer", "42"), #("test", "123")]
   let updated_request = request.set_query(request, query)
-  updated_request.query
-  |> should.equal(Some("answer=42&test=123"))
+  assert updated_request.query == Some("answer=42&test=123")
 
   let empty_query = []
   let updated_request = request.set_query(request, empty_query)
-  updated_request.query
-  |> should.equal(Some(""))
+  assert updated_request.query == Some("")
 
   let query = [#("foo bar", "x y")]
   let updated_request = request.set_query(request, query)
-  updated_request.query
-  |> should.equal(Some("foo%20bar=x%20y"))
+  assert updated_request.query == Some("foo%20bar=x%20y")
 }
 
 pub fn get_req_header_test() {
@@ -168,14 +159,10 @@ pub fn get_req_header_test() {
 
   let header_key = "GLEAM"
   let request = make_request([#("answer", "42"), #("gleam", "awesome")])
-  request
-  |> request.get_header(header_key)
-  |> should.equal(Ok("awesome"))
+  assert request.get_header(request, header_key) == Ok("awesome")
 
   let request = make_request([#("answer", "42")])
-  request
-  |> request.get_header(header_key)
-  |> should.equal(Error(Nil))
+  assert request.get_header(request, header_key) == Error(Nil)
 }
 
 pub fn set_req_body_test() {
@@ -202,8 +189,7 @@ pub fn set_req_body_test() {
     request
     |> request.set_body(body)
 
-  updated_request.body
-  |> should.equal(body)
+  assert updated_request.body == body
 }
 
 pub fn set_method_test() {
@@ -224,8 +210,7 @@ pub fn set_method_test() {
     request
     |> request.set_method(updated_request_method)
 
-  updated_request.method
-  |> should.equal(http.Post)
+  assert updated_request.method == http.Post
 }
 
 pub fn map_req_body_test() {
@@ -236,68 +221,59 @@ pub fn map_req_body_test() {
   let expected_updated_body = "dcba"
   let updated_request = request.map(request, string.reverse)
 
-  updated_request.body
-  |> should.equal(expected_updated_body)
+  assert updated_request.body == expected_updated_body
 }
 
 pub fn set_scheme_test() {
   let original_request = request.new()
 
-  original_request.scheme
-  |> should.equal(Https)
+  assert original_request.scheme == Https
 
   let updated_request =
     original_request
     |> request.set_scheme(http.Http)
 
   // scheme should be updated
-  updated_request.scheme
-  |> should.equal(http.Http)
+  assert updated_request.scheme == http.Http
 }
 
 pub fn set_host_test() {
   let new_host = "github"
   let original_request = request.new()
-  original_request.host
-  |> should.equal("localhost")
+  assert original_request.host == "localhost"
 
   let updated_request =
     original_request
     |> request.set_host(new_host)
 
   // host should be updated
-  updated_request.host
-  |> should.equal(new_host)
+  assert updated_request.host == new_host
 }
 
 pub fn set_port_test() {
   let original_request = request.new()
 
-  original_request.port
-  |> should.equal(None)
+  assert original_request.port == None
 
   let updated_request =
     original_request
     |> request.set_port(4000)
 
   // port should be updated
-  updated_request.port
-  |> should.equal(Some(4000))
+  assert updated_request.port == Some(4000)
 }
 
 pub fn set_path_test() {
   let new_path = "/gleam-lang"
   let original_request = request.new()
-  original_request.path
-  |> should.equal("")
+  assert original_request.path == ""
 
   let updated_request =
     original_request
     |> request.set_path(new_path)
 
   // path should be updated
-  updated_request.path
-  |> should.equal("/gleam-lang")
+  assert updated_request.path == "/gleam-lang"
 }
 
 pub fn set_req_header_test() {
@@ -314,16 +290,14 @@ pub fn set_req_header_test() {
     )
     |> request.set_header("gleam", "awesome")
 
-  request.headers
-  |> should.equal([#("gleam", "awesome")])
+  assert request.headers == [#("gleam", "awesome")]
 
   // Set updates existing
   let request =
     request
     |> request.set_header("gleam", "quite good")
 
-  request.headers
-  |> should.equal([#("gleam", "quite good")])
+  assert request.headers == [#("gleam", "quite good")]
 }
 
 pub fn set_request_header_maintains_value_casing_test() {
@@ -340,8 +314,7 @@ pub fn set_request_header_maintains_value_casing_test() {
     )
     |> request.set_header("gleam", "UPPERCASE_AWESOME")
 
-  request.headers
-  |> should.equal([#("gleam", "UPPERCASE_AWESOME")])
+  assert request.headers == [#("gleam", "UPPERCASE_AWESOME")]
 }
 
 pub fn set_request_header_lowercases_key_test() {
@@ -358,8 +331,7 @@ pub fn set_request_header_lowercases_key_test() {
     )
     |> request.set_header("UPPERCASE_GLEAM", "awesome")
 
-  request.headers
-  |> should.equal([#("uppercase_gleam", "awesome")])
+  assert request.headers == [#("uppercase_gleam", "awesome")]
 }
 
 pub fn prepend_req_header_test() {
@@ -377,63 +349,61 @@ pub fn prepend_req_header_test() {
     )
     |> request.prepend_header("answer", "42")
 
-  request.headers
-  |> should.equal([#("answer", "42")])
+  assert request.headers == [#("answer", "42")]
 
   let request =
     request
     |> request.prepend_header("gleam", "awesome")
 
   // request should have two headers now
-  request.headers
-  |> should.equal([#("gleam", "awesome"), #("answer", "42")])
+  assert request.headers == [#("gleam", "awesome"), #("answer", "42")]
 
   let request =
     request
     |> request.prepend_header("gleam", "awesome")
 
   // request repeats the existing header
-  request.headers
-  |> should.equal([
-    #("gleam", "awesome"),
-    #("gleam", "awesome"),
-    #("answer", "42"),
-  ])
+  assert request.headers
+    == [
+      #("gleam", "awesome"),
+      #("gleam", "awesome"),
+      #("answer", "42"),
+    ]
 }
 
 pub fn get_req_cookies_test() {
-  request.new()
-  |> request.prepend_header("cookie", "k1=v1; k2=v2")
-  |> request.get_cookies()
-  |> should.equal([#("k1", "v1"), #("k2", "v2")])
+  assert request.new()
+    |> request.prepend_header("cookie", "k1=v1; k2=v2")
+    |> request.get_cookies()
+    == [#("k1", "v1"), #("k2", "v2")]
 
   // Standard Header list syntax
-  request.new()
-  |> request.prepend_header("cookie", "k1=v1, k2=v2")
-  |> request.get_cookies()
-  |> should.equal([#("k1", "v1"), #("k2", "v2")])
+  assert request.new()
+    |> request.prepend_header("cookie", "k1=v1, k2=v2")
+    |> request.get_cookies()
+    == [#("k1", "v1"), #("k2", "v2")]
 
   // Spread over multiple headers
-  request.new()
-  |> request.prepend_header("cookie", "k2=v2")
-  |> request.prepend_header("cookie", "k1=v1")
-  |> request.get_cookies()
-  |> should.equal([#("k1", "v1"), #("k2", "v2")])
+  assert request.new()
+    |> request.prepend_header("cookie", "k2=v2")
+    |> request.prepend_header("cookie", "k1=v1")
+    |> request.get_cookies()
+    == [#("k1", "v1"), #("k2", "v2")]
 
-  request.new()
-  |> request.prepend_header("cookie", " k1  =  v1 ; k2=v2 ")
-  |> request.get_cookies()
-  |> should.equal([#("k1", "v1"), #("k2", "v2")])
+  assert request.new()
+    |> request.prepend_header("cookie", " k1  =  v1 ; k2=v2 ")
+    |> request.get_cookies()
+    == [#("k1", "v1"), #("k2", "v2")]
 
-  request.new()
-  |> request.prepend_header("cookie", "k1; =; =123")
-  |> request.get_cookies()
-  |> should.equal([])
+  assert request.new()
+    |> request.prepend_header("cookie", "k1; =; =123")
+    |> request.get_cookies()
+    == []
 
-  request.new()
-  |> request.prepend_header("cookie", "k\r1=v2; k1=v\r2")
-  |> request.get_cookies()
-  |> should.equal([])
+  assert request.new()
+    |> request.prepend_header("cookie", "k\r1=v2; k1=v\r2")
+    |> request.get_cookies()
+    == []
 }
 
 pub fn set_req_cookies_test() {
@@ -441,14 +411,12 @@ pub fn set_req_cookies_test() {
     request.new()
     |> request.set_cookie("k1", "v1")
 
-  request
-  |> request.get_header("cookie")
-  |> should.equal(Ok("k1=v1"))
+  assert request.get_header(request, "cookie") == Ok("k1=v1")
 
-  request
-  |> request.set_cookie("k2", "v2")
-  |> request.get_header("cookie")
-  |> should.equal(Ok("k1=v1; k2=v2"))
+  assert request
+    |> request.set_cookie("k2", "v2")
+    |> request.get_header("cookie")
+    == Ok("k1=v1; k2=v2")
 }
 
 pub fn set_req_cookies_overwrite_test() {
@@ -461,9 +429,8 @@ pub fn set_req_cookies_overwrite_test() {
     |> request.set_cookie("k2", "k2-updated")
     |> request.set_cookie("k4", "k4-updated")
 
-  request
-  |> request.get_header("cookie")
-  |> should.equal(Ok("k1=k1; k2=k2-updated; k3=k3; k4=k4-updated"))
+  assert request.get_header(request, "cookie")
+    == Ok("k1=k1; k2=k2-updated; k3=k3; k4=k4-updated")
 }
 
 pub fn remove_cookie_from_request_test() {
@@ -473,32 +440,24 @@ pub fn remove_cookie_from_request_test() {
     |> request.set_cookie("SECOND_COOKIE", "second")
     |> request.set_cookie("THIRD_COOKIE", "third")
 
-  req
-  |> request.get_header("cookie")
-  |> should.be_ok
-  |> should.equal(
-    "FIRST_COOKIE=first; SECOND_COOKIE=second; THIRD_COOKIE=third",
-  )
+  let assert Ok(value) = request.get_header(req, "cookie")
+  assert value == "FIRST_COOKIE=first; SECOND_COOKIE=second; THIRD_COOKIE=third"
 
   let modified_req =
     req
     |> request.remove_cookie("SECOND_COOKIE")
 
-  modified_req
-  |> request.get_header("cookie")
-  |> should.be_ok
-  |> should.equal("FIRST_COOKIE=first; THIRD_COOKIE=third")
+  let assert Ok(value) = request.get_header(modified_req, "cookie")
+  assert value == "FIRST_COOKIE=first; THIRD_COOKIE=third"
 }
 
 pub fn only_remove_matching_cookies_test() {
-  request.new()
-  |> request.set_cookie("FIRST_COOKIE", "first")
-  |> request.set_cookie("SECOND_COOKIE", "second")
-  |> request.set_cookie("THIRD_COOKIE", "third")
-  |> request.remove_cookie("SECOND")
-  |> request.get_header("cookie")
-  |> should.be_ok
-  |> should.equal(
-    "FIRST_COOKIE=first; SECOND_COOKIE=second; THIRD_COOKIE=third",
-  )
+  let assert Ok(value) =
+    request.new()
+    |> request.set_cookie("FIRST_COOKIE", "first")
+    |> request.set_cookie("SECOND_COOKIE", "second")
+    |> request.set_cookie("THIRD_COOKIE", "third")
+    |> request.remove_cookie("SECOND")
+    |> request.get_header("cookie")
+  assert value == "FIRST_COOKIE=first; SECOND_COOKIE=second; THIRD_COOKIE=third"
 }

--- a/test/gleam/http/response_test.gleam
+++ b/test/gleam/http/response_test.gleam
@@ -3,12 +3,11 @@ import gleam/http/cookie
 import gleam/http/response.{Response}
 import gleam/option.{None, Some}
 import gleam/string
-import gleeunit/should
 
 pub fn redirect_test() {
   let response = response.redirect("/other")
-  should.equal(303, response.status)
-  should.equal(Ok("/other"), response.get_header(response, "location"))
+  assert 303 == response.status
+  assert Ok("/other") == response.get_header(response, "location")
 }
 
 pub fn map_body_test() {
@@ -18,22 +17,21 @@ pub fn map_body_test() {
     response
     |> response.map(string.reverse)
 
-  updated_response.body
-  |> should.equal(expected_updated_body)
+  assert updated_response.body == expected_updated_body
 }
 
 pub fn try_map_body_test() {
   let transform = fn(_old_body) { Ok("new body") }
 
   let response = response.new(200)
-  response.try_map(response, transform)
-  |> should.equal(Ok(Response(200, [], "new body")))
+  assert response.try_map(response, transform)
+    == Ok(Response(200, [], "new body"))
 
   // transform function which fails should propogate error
   let transform_failure = fn(_old_body) { Error("transform failure") }
 
-  response.try_map(response, transform_failure)
-  |> should.equal(Error("transform failure"))
+  assert response.try_map(response, transform_failure)
+    == Error("transform failure")
 }
 
 pub fn get_header_test() {
@@ -42,17 +40,13 @@ pub fn get_header_test() {
     |> response.prepend_header("x-foo", "x")
     |> response.prepend_header("x-BAR", "y")
 
-  response.get_header(response, "x-foo")
-  |> should.equal(Ok("x"))
+  assert response.get_header(response, "x-foo") == Ok("x")
 
-  response.get_header(response, "X-Foo")
-  |> should.equal(Ok("x"))
+  assert response.get_header(response, "X-Foo") == Ok("x")
 
-  response.get_header(response, "x-baz")
-  |> should.equal(Error(Nil))
+  assert response.get_header(response, "x-baz") == Error(Nil)
 
-  response.headers
-  |> should.equal([#("x-bar", "y"), #("x-foo", "x")])
+  assert response.headers == [#("x-bar", "y"), #("x-foo", "x")]
 }
 
 pub fn set_header_test() {
@@ -63,8 +57,7 @@ pub fn set_header_test() {
     |> response.set_header("x-one", "x")
     |> response.set_header("x-two", "UPPERCASE")
 
-  response.headers
-  |> should.equal([#("x-one", "x"), #("x-two", "UPPERCASE")])
+  assert response.headers == [#("x-one", "x"), #("x-two", "UPPERCASE")]
 }
 
 pub fn set_body_test() {
@@ -72,8 +65,7 @@ pub fn set_body_test() {
     response.new(200)
     |> response.set_body("Hello, World!")
 
-  response.body
-  |> should.equal("Hello, World!")
+  assert response.body == "Hello, World!"
 }
 
 pub fn get_resp_cookies_test() {
@@ -87,10 +79,10 @@ pub fn get_resp_cookies_test() {
       same_site: None,
     )
 
-  response.new(200)
-  |> response.set_cookie("k1", "v1", empty)
-  |> response.get_cookies
-  |> should.equal([#("k1", "v1")])
+  assert response.new(200)
+    |> response.set_cookie("k1", "v1", empty)
+    |> response.get_cookies
+    == [#("k1", "v1")]
 
   let secure_with_attributes =
     cookie.Attributes(
@@ -102,21 +94,21 @@ pub fn get_resp_cookies_test() {
       same_site: None,
     )
 
-  response.new(200)
-  |> response.set_cookie("k1", "v1", secure_with_attributes)
-  |> response.get_cookies
-  |> should.equal([
-    #("k1", "v1"),
-    #("Max-Age", "100"),
-    #("Domain", "domain.test"),
-    #("Path", "/foo"),
-  ])
+  assert response.new(200)
+    |> response.set_cookie("k1", "v1", secure_with_attributes)
+    |> response.get_cookies
+    == [
+      #("k1", "v1"),
+      #("Max-Age", "100"),
+      #("Domain", "domain.test"),
+      #("Path", "/foo"),
+    ]
 
   // no response cookie
-  response.new(200)
-  |> response.prepend_header("k1", "v1")
-  |> response.get_cookies
-  |> should.equal([])
+  assert response.new(200)
+    |> response.prepend_header("k1", "v1")
+    |> response.get_cookies
+    == []
 }
 
 pub fn set_resp_cookie_test() {
@@ -129,15 +121,15 @@ pub fn set_resp_cookie_test() {
       http_only: False,
       same_site: None,
     )
-  response.new(200)
-  |> response.set_cookie("k1", "v1", empty)
-  |> response.get_header("set-cookie")
-  |> should.equal(Ok("k1=v1"))
+  assert response.new(200)
+    |> response.set_cookie("k1", "v1", empty)
+    |> response.get_header("set-cookie")
+    == Ok("k1=v1")
 
-  response.new(200)
-  |> response.set_cookie("k1", "v1", cookie.defaults(Http))
-  |> response.get_header("set-cookie")
-  |> should.equal(Ok("k1=v1; Path=/; HttpOnly; SameSite=Lax"))
+  assert response.new(200)
+    |> response.set_cookie("k1", "v1", cookie.defaults(Http))
+    |> response.get_header("set-cookie")
+    == Ok("k1=v1; Path=/; HttpOnly; SameSite=Lax")
 
   let secure =
     cookie.Attributes(
@@ -148,19 +140,19 @@ pub fn set_resp_cookie_test() {
       http_only: True,
       same_site: Some(cookie.Strict),
     )
-  response.new(200)
-  |> response.set_cookie("k1", "v1", secure)
-  |> response.get_header("set-cookie")
-  |> should.equal(Ok(
-    "k1=v1; Max-Age=100; Domain=domain.test; Path=/foo; Secure; HttpOnly; SameSite=Strict",
-  ))
+  assert response.new(200)
+    |> response.set_cookie("k1", "v1", secure)
+    |> response.get_header("set-cookie")
+    == Ok(
+      "k1=v1; Max-Age=100; Domain=domain.test; Path=/foo; Secure; HttpOnly; SameSite=Strict",
+    )
 }
 
 pub fn expire_resp_cookie_test() {
-  response.new(200)
-  |> response.expire_cookie("k1", cookie.defaults(Http))
-  |> response.get_header("set-cookie")
-  |> should.equal(Ok(
-    "k1=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/; HttpOnly; SameSite=Lax",
-  ))
+  assert response.new(200)
+    |> response.expire_cookie("k1", cookie.defaults(Http))
+    |> response.get_header("set-cookie")
+    == Ok(
+      "k1=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/; HttpOnly; SameSite=Lax",
+    )
 }

--- a/test/gleam/http_test.gleam
+++ b/test/gleam/http_test.gleam
@@ -1,252 +1,147 @@
 import gleam/http
-import gleeunit/should
 
 pub fn parse_method_test() {
-  "Connect"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("Connect")))
+  assert http.parse_method("Connect") == Ok(http.Other("Connect"))
 
-  "CONNECT"
-  |> http.parse_method
-  |> should.equal(Ok(http.Connect))
+  assert http.parse_method("CONNECT") == Ok(http.Connect)
 
-  "connect"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("connect")))
+  assert http.parse_method("connect") == Ok(http.Other("connect"))
 
-  "Delete"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("Delete")))
+  assert http.parse_method("Delete") == Ok(http.Other("Delete"))
 
-  "DELETE"
-  |> http.parse_method
-  |> should.equal(Ok(http.Delete))
+  assert http.parse_method("DELETE") == Ok(http.Delete)
 
-  "delete"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("delete")))
+  assert http.parse_method("delete") == Ok(http.Other("delete"))
 
-  "Get"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("Get")))
+  assert http.parse_method("Get") == Ok(http.Other("Get"))
 
-  "GET"
-  |> http.parse_method
-  |> should.equal(Ok(http.Get))
+  assert http.parse_method("GET") == Ok(http.Get)
 
-  "get"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("get")))
+  assert http.parse_method("get") == Ok(http.Other("get"))
 
-  "Head"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("Head")))
+  assert http.parse_method("Head") == Ok(http.Other("Head"))
 
-  "HEAD"
-  |> http.parse_method
-  |> should.equal(Ok(http.Head))
+  assert http.parse_method("HEAD") == Ok(http.Head)
 
-  "head"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("head")))
+  assert http.parse_method("head") == Ok(http.Other("head"))
 
-  "Options"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("Options")))
+  assert http.parse_method("Options") == Ok(http.Other("Options"))
 
-  "OPTIONS"
-  |> http.parse_method
-  |> should.equal(Ok(http.Options))
+  assert http.parse_method("OPTIONS") == Ok(http.Options)
 
-  "options"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("options")))
+  assert http.parse_method("options") == Ok(http.Other("options"))
 
-  "Patch"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("Patch")))
+  assert http.parse_method("Patch") == Ok(http.Other("Patch"))
 
-  "PATCH"
-  |> http.parse_method
-  |> should.equal(Ok(http.Patch))
+  assert http.parse_method("PATCH") == Ok(http.Patch)
 
-  "patch"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("patch")))
+  assert http.parse_method("patch") == Ok(http.Other("patch"))
 
-  "Post"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("Post")))
+  assert http.parse_method("Post") == Ok(http.Other("Post"))
 
-  "POST"
-  |> http.parse_method
-  |> should.equal(Ok(http.Post))
+  assert http.parse_method("POST") == Ok(http.Post)
 
-  "post"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("post")))
+  assert http.parse_method("post") == Ok(http.Other("post"))
 
-  "Put"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("Put")))
+  assert http.parse_method("Put") == Ok(http.Other("Put"))
 
-  "PUT"
-  |> http.parse_method
-  |> should.equal(Ok(http.Put))
+  assert http.parse_method("PUT") == Ok(http.Put)
 
-  "put"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("put")))
+  assert http.parse_method("put") == Ok(http.Other("put"))
 
-  "Trace"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("Trace")))
+  assert http.parse_method("Trace") == Ok(http.Other("Trace"))
 
-  "TRACE"
-  |> http.parse_method
-  |> should.equal(Ok(http.Trace))
+  assert http.parse_method("TRACE") == Ok(http.Trace)
 
-  "trace"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("trace")))
+  assert http.parse_method("trace") == Ok(http.Other("trace"))
 
-  "thingy"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("thingy")))
+  assert http.parse_method("thingy") == Ok(http.Other("thingy"))
 
-  "!#$%&'*+-.^_`|~abcABC123"
-  |> http.parse_method
-  |> should.equal(Ok(http.Other("!#$%&'*+-.^_`|~abcABC123")))
+  assert http.parse_method("!#$%&'*+-.^_`|~abcABC123")
+    == Ok(http.Other("!#$%&'*+-.^_`|~abcABC123"))
 
-  "In-valid method"
-  |> http.parse_method
-  |> should.equal(Error(Nil))
+  assert http.parse_method("In-valid method") == Error(Nil)
 }
 
 pub fn method_to_string_test() {
-  http.Connect
-  |> http.method_to_string
-  |> should.equal("CONNECT")
+  assert http.method_to_string(http.Connect) == "CONNECT"
 
-  http.Delete
-  |> http.method_to_string
-  |> should.equal("DELETE")
+  assert http.method_to_string(http.Delete) == "DELETE"
 
-  http.Get
-  |> http.method_to_string
-  |> should.equal("GET")
+  assert http.method_to_string(http.Get) == "GET"
 
-  http.Head
-  |> http.method_to_string
-  |> should.equal("HEAD")
+  assert http.method_to_string(http.Head) == "HEAD"
 
-  http.Options
-  |> http.method_to_string
-  |> should.equal("OPTIONS")
+  assert http.method_to_string(http.Options) == "OPTIONS"
 
-  http.Patch
-  |> http.method_to_string
-  |> should.equal("PATCH")
+  assert http.method_to_string(http.Patch) == "PATCH"
 
-  http.Post
-  |> http.method_to_string
-  |> should.equal("POST")
+  assert http.method_to_string(http.Post) == "POST"
 
-  http.Put
-  |> http.method_to_string
-  |> should.equal("PUT")
+  assert http.method_to_string(http.Put) == "PUT"
 
-  http.Trace
-  |> http.method_to_string
-  |> should.equal("TRACE")
+  assert http.method_to_string(http.Trace) == "TRACE"
 
-  http.Other("ok")
-  |> http.method_to_string
-  |> should.equal("ok")
+  assert http.method_to_string(http.Other("ok")) == "ok"
 
-  http.Other("nope")
-  |> http.method_to_string
-  |> should.equal("nope")
+  assert http.method_to_string(http.Other("nope")) == "nope"
 }
 
 pub fn scheme_to_string_test() {
-  http.Http
-  |> http.scheme_to_string
-  |> should.equal("http")
+  assert http.scheme_to_string(http.Http) == "http"
 
-  http.Https
-  |> http.scheme_to_string
-  |> should.equal("https")
+  assert http.scheme_to_string(http.Https) == "https"
 }
 
 pub fn scheme_from_string_test() {
-  "http"
-  |> http.scheme_from_string
-  |> should.equal(Ok(http.Http))
+  assert http.scheme_from_string("http") == Ok(http.Http)
 
-  "https"
-  |> http.scheme_from_string
-  |> should.equal(Ok(http.Https))
+  assert http.scheme_from_string("https") == Ok(http.Https)
 
-  "ftp"
-  |> http.scheme_from_string
-  |> should.equal(Error(Nil))
+  assert http.scheme_from_string("ftp") == Error(Nil)
 }
 
 pub fn parse_content_disposition_1_test() {
-  http.parse_content_disposition("inline")
-  |> should.equal(Ok(http.ContentDisposition("inline", [])))
+  assert http.parse_content_disposition("inline")
+    == Ok(http.ContentDisposition("inline", []))
 
-  http.parse_content_disposition("attachment")
-  |> should.equal(Ok(http.ContentDisposition("attachment", [])))
+  assert http.parse_content_disposition("attachment")
+    == Ok(http.ContentDisposition("attachment", []))
 
-  http.parse_content_disposition(
-    "attachment; filename=genome.jpeg; modification-date=\"Wed, 12 Feb 1997 16:29:51 -0500\";",
-  )
-  |> should.equal(
-    Ok(
+  assert http.parse_content_disposition(
+      "attachment; filename=genome.jpeg; modification-date=\"Wed, 12 Feb 1997 16:29:51 -0500\";",
+    )
+    == Ok(
       http.ContentDisposition("attachment", [
         #("filename", "genome.jpeg"),
         #("modification-date", "Wed, 12 Feb 1997 16:29:51 -0500"),
       ]),
-    ),
-  )
+    )
 
-  http.parse_content_disposition("form-data; name=\"user\"")
-  |> should.equal(Ok(http.ContentDisposition("form-data", [#("name", "user")])))
+  assert http.parse_content_disposition("form-data; name=\"user\"")
+    == Ok(http.ContentDisposition("form-data", [#("name", "user")]))
 
-  http.parse_content_disposition("form-data; NAME=\"submit-name\"")
-  |> should.equal(
-    Ok(http.ContentDisposition("form-data", [#("name", "submit-name")])),
-  )
+  assert http.parse_content_disposition("form-data; NAME=\"submit-name\"")
+    == Ok(http.ContentDisposition("form-data", [#("name", "submit-name")]))
 
-  http.parse_content_disposition(
-    "form-data; name=\"files\"; filename=\"file1.txt\"",
-  )
-  |> should.equal(
-    Ok(
+  assert http.parse_content_disposition(
+      "form-data; name=\"files\"; filename=\"file1.txt\"",
+    )
+    == Ok(
       http.ContentDisposition("form-data", [
         #("name", "files"),
         #("filename", "file1.txt"),
       ]),
-    ),
-  )
+    )
 
-  http.parse_content_disposition("file; filename=\"file1.txt\"")
-  |> should.equal(
-    Ok(http.ContentDisposition("file", [#("filename", "file1.txt")])),
-  )
+  assert http.parse_content_disposition("file; filename=\"file1.txt\"")
+    == Ok(http.ContentDisposition("file", [#("filename", "file1.txt")]))
 
-  http.parse_content_disposition("file; filename=\"file2.gif\"")
-  |> should.equal(
-    Ok(http.ContentDisposition("file", [#("filename", "file2.gif")])),
-  )
+  assert http.parse_content_disposition("file; filename=\"file2.gif\"")
+    == Ok(http.ContentDisposition("file", [#("filename", "file2.gif")]))
 
-  http.parse_content_disposition("file; filename=\"file2\\\".gif\"")
-  |> should.equal(
-    Ok(http.ContentDisposition("file", [#("filename", "file2\".gif")])),
-  )
+  assert http.parse_content_disposition("file; filename=\"file2\\\".gif\"")
+    == Ok(http.ContentDisposition("file", [#("filename", "file2\".gif")]))
 
-  http.parse_content_disposition("file; filename=\"file2")
-  |> should.equal(Error(Nil))
+  assert http.parse_content_disposition("file; filename=\"file2") == Error(Nil)
 }


### PR DESCRIPTION
With this all the tests now use the `assert` syntax. I used `asset` to rewrite them!