### PR TITLE
Various improvements

### DIFF
--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -28,6 +28,25 @@ pub type Method {
   Other(String)
 }
 
+pub fn parse_method(method: String) -> Result(Method, Nil) {
+  case method {
+    "CONNECT" -> Ok(Connect)
+    "DELETE" -> Ok(Delete)
+    "GET" -> Ok(Get)
+    "HEAD" -> Ok(Head)
+    "OPTIONS" -> Ok(Options)
+    "PATCH" -> Ok(Patch)
+    "POST" -> Ok(Post)
+    "PUT" -> Ok(Put)
+    "TRACE" -> Ok(Trace)
+    method ->
+      case is_valid_token(method) {
+        True -> Ok(Other(method))
+        False -> Error(Nil)
+      }
+  }
+}
+
 // A token is defined as:
 //
 //   token         = 1*tchar
@@ -46,52 +65,97 @@ pub type Method {
 // (From https://www.rfc-editor.org/rfc/rfc5234#appendix-B.1)
 //
 fn is_valid_token(token: String) -> Bool {
-  bit_array.from_string(token)
-  |> do_is_valid_token(True)
-}
-
-fn do_is_valid_token(bytes: BitArray, acc: Bool) -> Bool {
-  case bytes, acc {
-    <<char, rest:bytes>>, True -> do_is_valid_token(rest, is_valid_tchar(char))
-    _, _ -> acc
+  case token {
+    // A token must have at least a single valid characther
+    "" -> False
+    _ -> is_valid_token_loop(token)
   }
 }
 
-fn is_valid_tchar(character: Int) -> Bool {
-  case character {
-    // "!" | "#" | "$" | "%" | "&" | "'" | "*" | "+" | "-"
-    // | "." | "^" | "_" | "`" | "|" | "~"
-    33 | 35 | 36 | 37 | 38 | 39 | 42 | 43 | 45 | 46 | 94 | 95 | 96 | 124 | 126 ->
-      True
-    // DIGIT
-    character if character >= 0x30 && character <= 0x39 -> True
-    // ALPHA
-    character
-      if { character >= 0x41 && character <= 0x5A }
-      || { character >= 0x61 && character <= 0x7A }
-    -> True
+fn is_valid_token_loop(token: String) -> Bool {
+  case token {
+    "" -> True
+    // SYMBOLS
+    "!" <> rest
+    | "#" <> rest
+    | "$" <> rest
+    | "%" <> rest
+    | "&" <> rest
+    | "'" <> rest
+    | "*" <> rest
+    | "+" <> rest
+    | "-" <> rest
+    | "." <> rest
+    | "^" <> rest
+    | "_" <> rest
+    | "`" <> rest
+    | "|" <> rest
+    | "~" <> rest
+    | // DIGITS
+      "0" <> rest
+    | "1" <> rest
+    | "2" <> rest
+    | "3" <> rest
+    | "4" <> rest
+    | "5" <> rest
+    | "6" <> rest
+    | "7" <> rest
+    | "8" <> rest
+    | "9" <> rest
+    | // ALPHA
+      "A" <> rest
+    | "B" <> rest
+    | "C" <> rest
+    | "D" <> rest
+    | "E" <> rest
+    | "F" <> rest
+    | "G" <> rest
+    | "H" <> rest
+    | "I" <> rest
+    | "J" <> rest
+    | "K" <> rest
+    | "L" <> rest
+    | "M" <> rest
+    | "N" <> rest
+    | "O" <> rest
+    | "P" <> rest
+    | "Q" <> rest
+    | "R" <> rest
+    | "S" <> rest
+    | "T" <> rest
+    | "U" <> rest
+    | "V" <> rest
+    | "W" <> rest
+    | "X" <> rest
+    | "Y" <> rest
+    | "Z" <> rest
+    | "a" <> rest
+    | "b" <> rest
+    | "c" <> rest
+    | "d" <> rest
+    | "e" <> rest
+    | "f" <> rest
+    | "g" <> rest
+    | "h" <> rest
+    | "i" <> rest
+    | "j" <> rest
+    | "k" <> rest
+    | "l" <> rest
+    | "m" <> rest
+    | "n" <> rest
+    | "o" <> rest
+    | "p" <> rest
+    | "q" <> rest
+    | "r" <> rest
+    | "s" <> rest
+    | "t" <> rest
+    | "u" <> rest
+    | "v" <> rest
+    | "w" <> rest
+    | "x" <> rest
+    | "y" <> rest
+    | "z" <> rest -> is_valid_token_loop(rest)
     _ -> False
-  }
-}
-
-// TODO: check if the a is a valid HTTP method (i.e. it is a token, as per the
-// spec) and return Ok(Other(s)) if so.
-pub fn parse_method(method: String) -> Result(Method, Nil) {
-  case method {
-    "CONNECT" -> Ok(Connect)
-    "DELETE" -> Ok(Delete)
-    "GET" -> Ok(Get)
-    "HEAD" -> Ok(Head)
-    "OPTIONS" -> Ok(Options)
-    "PATCH" -> Ok(Patch)
-    "POST" -> Ok(Post)
-    "PUT" -> Ok(Put)
-    "TRACE" -> Ok(Trace)
-    method ->
-      case is_valid_token(method) {
-        True -> Ok(Other(method))
-        False -> Error(Nil)
-      }
   }
 }
 

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -45,8 +45,8 @@ pub type Method {
 //
 // (From https://www.rfc-editor.org/rfc/rfc5234#appendix-B.1)
 //
-fn is_valid_token(s: String) -> Bool {
-  bit_array.from_string(s)
+fn is_valid_token(token: String) -> Bool {
+  bit_array.from_string(token)
   |> do_is_valid_token(True)
 }
 
@@ -57,24 +57,27 @@ fn do_is_valid_token(bytes: BitArray, acc: Bool) -> Bool {
   }
 }
 
-fn is_valid_tchar(ch: Int) -> Bool {
-  case ch {
+fn is_valid_tchar(character: Int) -> Bool {
+  case character {
     // "!" | "#" | "$" | "%" | "&" | "'" | "*" | "+" | "-"
     // | "." | "^" | "_" | "`" | "|" | "~"
     33 | 35 | 36 | 37 | 38 | 39 | 42 | 43 | 45 | 46 | 94 | 95 | 96 | 124 | 126 ->
       True
     // DIGIT
-    ch if ch >= 0x30 && ch <= 0x39 -> True
+    character if character >= 0x30 && character <= 0x39 -> True
     // ALPHA
-    ch if ch >= 0x41 && ch <= 0x5A || ch >= 0x61 && ch <= 0x7A -> True
+    character
+      if { character >= 0x41 && character <= 0x5A }
+      || { character >= 0x61 && character <= 0x7A }
+    -> True
     _ -> False
   }
 }
 
 // TODO: check if the a is a valid HTTP method (i.e. it is a token, as per the
 // spec) and return Ok(Other(s)) if so.
-pub fn parse_method(s: String) -> Result(Method, Nil) {
-  case s {
+pub fn parse_method(method: String) -> Result(Method, Nil) {
+  case method {
     "CONNECT" -> Ok(Connect)
     "DELETE" -> Ok(Delete)
     "GET" -> Ok(Get)
@@ -84,9 +87,9 @@ pub fn parse_method(s: String) -> Result(Method, Nil) {
     "POST" -> Ok(Post)
     "PUT" -> Ok(Put)
     "TRACE" -> Ok(Trace)
-    s ->
-      case is_valid_token(s) {
-        True -> Ok(Other(s))
+    method ->
+      case is_valid_token(method) {
+        True -> Ok(Other(method))
         False -> Error(Nil)
       }
   }
@@ -103,7 +106,7 @@ pub fn method_to_string(method: Method) -> String {
     Post -> "POST"
     Put -> "PUT"
     Trace -> "TRACE"
-    Other(s) -> s
+    Other(method) -> method
   }
 }
 

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -50,7 +50,7 @@ fn is_valid_token(s: String) -> Bool {
   |> do_is_valid_token(True)
 }
 
-fn do_is_valid_token(bytes: BitArray, acc: Bool) {
+fn do_is_valid_token(bytes: BitArray, acc: Bool) -> Bool {
   case bytes, acc {
     <<char, rest:bytes>>, True -> do_is_valid_token(rest, is_valid_tchar(char))
     _, _ -> acc
@@ -73,7 +73,7 @@ fn is_valid_tchar(ch: Int) -> Bool {
 
 // TODO: check if the a is a valid HTTP method (i.e. it is a token, as per the
 // spec) and return Ok(Other(s)) if so.
-pub fn parse_method(s) -> Result(Method, Nil) {
+pub fn parse_method(s: String) -> Result(Method, Nil) {
   case s {
     "CONNECT" -> Ok(Connect)
     "DELETE" -> Ok(Delete)

--- a/src/gleam/http/cookie.gleam
+++ b/src/gleam/http/cookie.gleam
@@ -110,13 +110,15 @@ pub fn parse(cookie_string: String) -> List(#(String, String)) {
 }
 
 fn check_token(token: String) -> Result(Nil, Nil) {
-  case string.pop_grapheme(token) {
-    Error(Nil) -> Ok(Nil)
-    Ok(#(" ", _)) -> Error(Nil)
-    Ok(#("\t", _)) -> Error(Nil)
-    Ok(#("\r", _)) -> Error(Nil)
-    Ok(#("\n", _)) -> Error(Nil)
-    Ok(#("\f", _)) -> Error(Nil)
-    Ok(#(_, rest)) -> check_token(rest)
+  let contains_invalid_charachter =
+    string.contains(token, " ")
+    || string.contains(token, "\t")
+    || string.contains(token, "\r")
+    || string.contains(token, "\n")
+    || string.contains(token, "\f")
+
+  case contains_invalid_charachter {
+    True -> Error(Nil)
+    False -> Ok(Nil)
   }
 }

--- a/src/gleam/http/cookie.gleam
+++ b/src/gleam/http/cookie.gleam
@@ -14,7 +14,7 @@ pub type SameSitePolicy {
   None
 }
 
-fn same_site_to_string(policy) {
+fn same_site_to_string(policy: SameSitePolicy) -> String {
   case policy {
     Lax -> "Lax"
     Strict -> "Strict"
@@ -37,7 +37,7 @@ pub type Attributes {
 /// Helper to create sensible default attributes for a set cookie.
 ///
 /// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Attributes
-pub fn defaults(scheme: Scheme) {
+pub fn defaults(scheme: Scheme) -> Attributes {
   Attributes(
     max_age: option.None,
     domain: option.None,

--- a/src/gleam/http/cookie.gleam
+++ b/src/gleam/http/cookie.gleam
@@ -98,8 +98,8 @@ pub fn parse(cookie_string: String) -> List(#(String, String)) {
       Ok(#("", _)) -> Error(Nil)
       Ok(#(key, value)) -> {
         let key = string.trim(key)
-        let value = string.trim(value)
         use _ <- result.try(check_token(key))
+        let value = string.trim(value)
         use _ <- result.try(check_token(value))
         Ok(#(key, value))
       }

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -251,15 +251,12 @@ pub fn set_cookie(req: Request(body), name: String, value: String) {
 pub fn get_cookies(req) -> List(#(String, String)) {
   let Request(headers:, ..) = req
 
-  headers
-  |> list.filter_map(fn(header) {
-    let #(name, value) = header
-    case name {
-      "cookie" -> Ok(cookie.parse(value))
-      _ -> Error(Nil)
+  list.flat_map(headers, fn(header) {
+    case header {
+      #("cookie", value) -> cookie.parse(value)
+      _ -> []
     }
   })
-  |> list.flatten()
 }
 
 /// Remove a cookie from a request

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -224,23 +224,20 @@ pub fn set_path(req: Request(body), path: String) -> Request(body) {
 
 /// Set a cookie on a request, replacing any previous cookie with that name.
 ///
-/// All cookies stored in a single header named `cookie`. There should be
-/// at most one header with the name `cookie`, otherwise this function cannot
-/// guarentee that previous cookies with the same name are replaced.
+/// All cookies should be stored in a single header named `cookie`.
+/// There should be at most one header with the name `cookie`, otherwise this
+/// function cannot guarentee that previous cookies with the same name are
+/// replaced.
 ///
 pub fn set_cookie(req: Request(body), name: String, value: String) {
   // Get the cookies
   let #(cookies, headers) =
     list.key_pop(req.headers, "cookie") |> result.unwrap(#("", req.headers))
 
-  // Parse them
-  let cookies =
-    string.split(cookies, ";")
-    |> list.filter_map(fn(c) { string.trim_start(c) |> string.split_once("=") })
-
   // Set the new cookie, replacing any previous one with the same name
   let cookies =
-    list.key_set(cookies, name, value)
+    cookie.parse(cookies)
+    |> list.key_set(name, value)
     |> list.map(fn(pair) { pair.0 <> "=" <> pair.1 })
     |> string.join("; ")
 

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -27,7 +27,7 @@ pub type Request(body) {
 
 /// Return the uri that a request was sent to.
 ///
-pub fn to_uri(request: Request(a)) -> Uri {
+pub fn to_uri(request: Request(body)) -> Uri {
   Uri(
     scheme: option.Some(http.scheme_to_string(request.scheme)),
     userinfo: option.None,

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -229,7 +229,11 @@ pub fn set_path(req: Request(body), path: String) -> Request(body) {
 /// function cannot guarentee that previous cookies with the same name are
 /// replaced.
 ///
-pub fn set_cookie(req: Request(body), name: String, value: String) {
+pub fn set_cookie(
+  req: Request(body),
+  name: String,
+  value: String,
+) -> Request(body) {
   // Get the cookies
   let #(cookies, headers) =
     list.key_pop(req.headers, "cookie") |> result.unwrap(#("", req.headers))
@@ -248,7 +252,7 @@ pub fn set_cookie(req: Request(body), name: String, value: String) {
 ///
 /// Note badly formed cookie pairs will be ignored.
 /// RFC6265 specifies that invalid cookie names/attributes should be ignored.
-pub fn get_cookies(req) -> List(#(String, String)) {
+pub fn get_cookies(req: Request(body)) -> List(#(String, String)) {
   let Request(headers:, ..) = req
 
   list.flat_map(headers, fn(header) {
@@ -263,7 +267,7 @@ pub fn get_cookies(req) -> List(#(String, String)) {
 ///
 /// Remove a cookie from the request. If no cookie is found return the request
 /// unchanged. This will not remove the cookie from the client.
-pub fn remove_cookie(req: Request(body), name: String) {
+pub fn remove_cookie(req: Request(body), name: String) -> Request(body) {
   case list.key_pop(req.headers, "cookie") {
     Ok(#(cookies_string, headers)) -> {
       let new_cookies_string =

--- a/src/gleam/http/request.gleam
+++ b/src/gleam/http/request.gleam
@@ -157,14 +157,12 @@ pub fn set_query(
   req: Request(body),
   query: List(#(String, String)),
 ) -> Request(body) {
-  let pair = fn(t: #(String, String)) {
-    uri.percent_encode(t.0) <> "=" <> uri.percent_encode(t.1)
-  }
   let query =
-    query
-    |> list.map(pair)
-    |> list.intersperse("&")
-    |> string.concat
+    list.map(query, fn(pair) {
+      let #(key, value) = pair
+      uri.percent_encode(key) <> "=" <> uri.percent_encode(value)
+    })
+    |> string.join(with: "&")
     |> option.Some
 
   Request(..req, query:)

--- a/src/gleam/http/response.gleam
+++ b/src/gleam/http/response.gleam
@@ -119,15 +119,12 @@ pub fn redirect(uri: String) -> Response(String) {
 pub fn get_cookies(resp: Response(a)) -> List(#(String, String)) {
   let Response(headers:, ..) = resp
 
-  headers
-  |> list.filter_map(fn(header) {
-    let #(name, value) = header
-    case name {
-      "set-cookie" -> Ok(cookie.parse(value))
-      _ -> Error(Nil)
+  list.flat_map(headers, fn(header) {
+    case header {
+      #("set-cookie", value) -> cookie.parse(value)
+      _ -> []
     }
   })
-  |> list.flatten()
 }
 
 /// Set a cookie value for a client

--- a/src/gleam/http/response.gleam
+++ b/src/gleam/http/response.gleam
@@ -116,7 +116,7 @@ pub fn redirect(uri: String) -> Response(String) {
 ///
 /// Badly formed cookies will be discarded.
 ///
-pub fn get_cookies(resp) -> List(#(String, String)) {
+pub fn get_cookies(resp: Response(a)) -> List(#(String, String)) {
   let Response(headers:, ..) = resp
 
   headers

--- a/src/gleam/http/response.gleam
+++ b/src/gleam/http/response.gleam
@@ -116,7 +116,7 @@ pub fn redirect(uri: String) -> Response(String) {
 ///
 /// Badly formed cookies will be discarded.
 ///
-pub fn get_cookies(resp: Response(a)) -> List(#(String, String)) {
+pub fn get_cookies(resp: Response(body)) -> List(#(String, String)) {
   let Response(headers:, ..) = resp
 
   list.flat_map(headers, fn(header) {
@@ -130,11 +130,11 @@ pub fn get_cookies(resp: Response(a)) -> List(#(String, String)) {
 /// Set a cookie value for a client
 ///
 pub fn set_cookie(
-  response: Response(t),
+  response: Response(body),
   name: String,
   value: String,
   attributes: cookie.Attributes,
-) -> Response(t) {
+) -> Response(body) {
   prepend_header(
     response,
     "set-cookie",
@@ -146,10 +146,10 @@ pub fn set_cookie(
 ///
 /// Note: The attributes value should be the same as when the response cookie was set.
 pub fn expire_cookie(
-  response: Response(t),
+  response: Response(body),
   name: String,
   attributes: cookie.Attributes,
-) -> Response(t) {
+) -> Response(body) {
   let attrs = cookie.Attributes(..attributes, max_age: option.Some(0))
   set_cookie(response, name, "", attrs)
 }

--- a/src/gleam/http/service.gleam
+++ b/src/gleam/http/service.gleam
@@ -14,7 +14,10 @@ pub type Middleware(before_req, before_resp, after_req, after_resp) =
     fn(Request(after_req)) -> Response(after_resp)
 
 @deprecated("Use middleware packages such as Wisp or Glen instead")
-pub fn map_response_body(service, with mapper: fn(a) -> b) {
+pub fn map_response_body(
+  service: fn(c) -> Response(a),
+  with mapper: fn(a) -> b,
+) -> fn(c) -> Response(b) {
   fn(req) {
     req
     |> service
@@ -23,7 +26,11 @@ pub fn map_response_body(service, with mapper: fn(a) -> b) {
 }
 
 @deprecated("Use middleware packages such as Wisp or Glen instead")
-pub fn prepend_response_header(service, key: String, value: String) {
+pub fn prepend_response_header(
+  service: fn(a) -> Response(b),
+  key: String,
+  value: String,
+) -> fn(a) -> Response(b) {
   fn(req) {
     req
     |> service
@@ -31,7 +38,7 @@ pub fn prepend_response_header(service, key: String, value: String) {
   }
 }
 
-fn ensure_post(req: Request(a)) {
+fn ensure_post(req: Request(a)) -> Result(Request(a), Nil) {
   case req.method {
     Post -> Ok(req)
     _ -> Error(Nil)
@@ -49,7 +56,7 @@ fn get_override_method(request: Request(t)) -> Result(http.Method, Nil) {
 }
 
 @deprecated("Use middleware packages such as Wisp or Glen instead")
-pub fn method_override(service) {
+pub fn method_override(service: fn(Request(a)) -> b) -> fn(Request(a)) -> b {
   fn(request) {
     request
     |> ensure_post


### PR DESCRIPTION
Going through the codebase I noticed that it could make use of some small tweaks so I've made a series of small improvements:
- simplify `http.is_valid_token`
- remove single letter names in favour of more descriptive names
- use consistent generic type name
- simplify the `response.get_cookies` function
- add missing type annotations to all functions
- make sure `request.remove_cookie` correctly parses the cookies and simplify it
- simplify the `request.get_cookies` function
- make sure `request.set_cookie` correctly parses the cookies and simplify it
- simplify the `request.set_query` function
- avoid wasted work in `cookie.parse`
- simplify `cookie_attributes_to_list` function
- improve performance of the `cookie.check_token` function

I've been careful to keep each into its own separate commit to make it easier to go over each individually (and revert something if it's not wanted)

A little note on `cookie.check_token` performance, here's the measurements for the Erlang target:
```
100 characters long token
            ips    average   deviation    median     99th %   memory usage
new    927.43 K    1.08 μs   ±2058.75%   0.63 μs    1.04 μs        0.98 KB
old    192.89 K    5.18 μs    ±149.60%   4.67 μs   16.96 μs       22.67 KB
old is 4.81x slower +4.11 μs
       23.22x memory usage +21.70 KB

10_000 characters long token
            ips    average   deviation    median     99th %   memory usage
new    428.43 K    2.33 μs   ±715.70%    1.79 μs    5.71 μs     0.00095 MB
old      2.24 K  445.70 μs     ±5.56%  442.08 μs  533.40 μs        2.13 MB
old is 190.95x slower +443.37 μs
       2230.02x memory usage +2.13 MB
```
And here's the improvement on the JS target (measured on Node 24.7.0):
```
benchmark                   avg (min … max) p75 / p99
------------------------------------------- ----------
old 100                      133.80 µs/iter 136.13 µs
                      (97.58 µs … 14.36 ms) 192.00 µs
                    (  3.91 kb … 277.20 kb)  53.86 kb
new 100                      138.55 ns/iter 141.68 ns   965x faster
                    (119.96 ns … 191.57 ns) 167.90 ns
                    ( 46.53  b … 315.38  b) 176.12  b   86x less memory

old 10000                     57.81 ms/iter  59.01 ms
                      (55.02 ms … 60.69 ms)  59.32 ms
                    (  5.11 mb …   5.11 mb)   5.11 mb
new 10000                      1.23 µs/iter   1.25 µs   47000x faster
                        (1.17 µs … 1.33 µs)   1.33 µs
                    (166.84  b … 176.16  b) 176.01  b   32000x less memory
```
The difference is staggering!


