### PR TITLE
Use literal syntax and optimise code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- The performance of the `parse_multipart_headers` and `parse_multipart_body`
+  functions has been improved.
+
 ## v4.2.0 - 2025-09-15
 
 - The performance of the cookie and method parsing functions have been

--- a/src/gleam/http.gleam
+++ b/src/gleam/http.gleam
@@ -455,20 +455,20 @@ pub fn parse_multipart_body(
   data: BitArray,
   boundary: String,
 ) -> Result(MultipartBody, Nil) {
-  boundary
-  |> bit_array.from_string
-  |> parse_body_with_bit_array(data, _)
+  let boundary = bit_array.from_string(boundary)
+  let boundary_bytes = bit_array.byte_size(boundary)
+  do_parse_multipart_body(data, boundary, boundary_bytes)
 }
 
-fn parse_body_with_bit_array(
+fn do_parse_multipart_body(
   data: BitArray,
   boundary: BitArray,
+  boundary_bytes: Int,
 ) -> Result(MultipartBody, Nil) {
-  let bsize = bit_array.byte_size(boundary)
-  let prefix = bit_array.slice(data, 0, 2 + bsize)
-  case prefix == Ok(<<45, 45, boundary:bits>>) {
-    True -> Ok(MultipartBody(<<>>, done: False, remaining: data))
-    False -> parse_body_loop(data, boundary, <<>>)
+  case data {
+    <<"--", found:size(boundary_bytes)-bytes, _:bits>> if found == boundary ->
+      Ok(MultipartBody(<<>>, done: False, remaining: data))
+    _ -> parse_body_loop(data, boundary, <<>>)
   }
 }
 


### PR DESCRIPTION
Now that support for bit array pattern matching is the same on both targets we can rewrite the http parsing using case expressions instead of slicing.
I've also been careful in optimising the usage of bit arrays here, to make sure it's always reusing match context as much as possible on the Erlang target: analysing the code with `ERL_COMPILER_OPTIONS=bin_opt_info` the only calls that cannot be optimised are the ones where we have to stop the parsing and ask for more data, which is impossible to avoid. The happy path however never does any needless materialisation of a matching context!

The performance improvement is quite nice. Here's measurements when using `parse_multipart_body` to parse a body in its entirety:
```
Name   ips        average   deviation    median    99th %   Memory usage
new    380.78 K   2.63 μs    ±215.68%   2.54 μs   3.38 μs        0.26 KB
old    135.66 K   7.37 μs     ±38.95%   7.17 μs   9.67 μs       38.72 KB
old is   2.81x  slower +4.75 μs
    uses 150.18x memory +38.46 KB
```
The code that goes over the entire body is this:
```gleam
fn parse_all(body: BitArray, boundary: String) -> Nil {
  case http.parse_multipart_body(body, boundary) {
    Ok(http.MultipartBody(chunk: _, done: True, remaining:)) ->
      parse_all_old(remaining, boundary)
    Ok(http.MultipartBody(chunk: _, done: False, remaining: _)) -> Nil
    Ok(http.MoreRequiredForBody(..)) -> panic as "incomplete"
    Error(_) -> panic as "error"
  }
}
```
Finaly the body I tested it with is built like this:
```gleam
let middle =
    "--2a8ae6ad-f4ad-4d9a-a92c-6d217011fe0f\r
\r
something something.\r
something something.\r
something something.\r
something something.\r
something something.\r
something something.\r
something something.\r
something something.\r
something something.\r
something something.\r
something something.\r
something something.\r
something something.\r
"
  |> string.repeat(100)

let body = <<
  "This is the preamble.  It is to be ignored, though it\r
is a handy place for mail composers to include an\r
explanatory note to non-MIME compliant readers.\r",
  middle:utf8,
  "--2a8ae6ad-f4ad-4d9a-a92c-6d217011fe0f--\r
This is the epilogue.  It is also to be ignored.",
>>
```